### PR TITLE
fix UnboundLocalError preventing integration start

### DIFF
--- a/custom_components/teslemetry/__init__.py
+++ b/custom_components/teslemetry/__init__.py
@@ -116,6 +116,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                             {"vin": vin, "errors": None},
                         ),
                     )
+
+                    vehicles.append(
+                        TeslemetryVehicleData(
+                            api=api,
+                            coordinator=coordinator,
+                            stream=stream,
+                            vin=vin,
+                            device=device,
+                            remove_listeners=remove_listeners,
+                        )
+                    )
             except TeslemetryStreamVehicleNotConfigured:
                 LOGGER.warning(
                     "Vehicle %s is not configured for streaming. Configure at https://teslemetry.com/console/%s",
@@ -128,16 +139,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 )
                 LOGGER.debug(e)
 
-            vehicles.append(
-                TeslemetryVehicleData(
-                    api=api,
-                    coordinator=coordinator,
-                    stream=stream,
-                    vin=vin,
-                    device=device,
-                    remove_listeners=remove_listeners,
-                )
-            )
         elif "energy_site_id" in product and Scope.ENERGY_DEVICE_DATA in scopes:
             site_id = product["energy_site_id"]
             api = EnergySpecific(teslemetry.energy, site_id)


### PR DESCRIPTION
I noticed today after the new update that my integration wouldn't load. It's the first time I have ever looked at HASS or integration code, but it looked like it was a scoping issue where it couldn't find `remove_listeners` in the right scope. 

If it's incorrect, I'm sorry but when I made the change locally it seemed to have fixed my issue and allow my integration to load :) 