### PR TITLE
Add names and icons for streaming fields

### DIFF
--- a/custom_components/teslemetry/icons.json
+++ b/custom_components/teslemetry/icons.json
@@ -285,6 +285,219 @@
       },
       "solar_energy_exported": {
         "default": "mdi:solar-power-variant"
+      },
+      "stream_bmsstate": {
+        "default": "mdi:battery-sync"
+      },
+      "stream_brakepedalpos": {
+        "default": "mdi:car-brake-alert"
+      },
+      "stream_brickvoltagemax": {
+        "default": "mdi:battery-arrow-up"
+      },
+      "stream_brickvoltagemin": {
+        "default": "mdi:battery-arrow-down"
+      },
+      "stream_cartype": {
+        "default": "mdi:car"
+      },
+      "stream_chargeport": {
+        "default": "mdi:ev-plug-tesla"
+      },
+      "stream_cruisefollowdistance": {
+        "default": "mdi:car-cruise-control"
+      },
+      "stream_cruisesetspeed": {
+        "default": "mdi:car-cruise-control"
+      },
+      "stream_cruisestate": {
+        "default": "mdi:car-cruise-control"
+      },
+      "stream_dcchargingenergyin": {
+        "default": "mdi:lightning-bolt"
+      },
+      "stream_dcchargingpower": {
+        "default": "mdi:flash"
+      },
+      "stream_dcdcenable": {
+        "default": "mdi:flash-triangle"
+      },
+      "stream_destinationlocation": {
+        "default": "mdi:map-marker"
+      },
+      "stream_diaxlespeedf": {
+        "default": "mdi:speedometer"
+      },
+      "stream_diaxlespeedr": {
+        "default": "mdi:speedometer"
+      },
+      "stream_diaxlespeedrel": {
+        "default": "mdi:speedometer"
+      },
+      "stream_diaxlespeedrer": {
+        "default": "mdi:speedometer"
+      },
+      "stream_diheatsinktf": {
+        "default": "mdi:radiator"
+      },
+      "stream_diheatsinktr": {
+        "default": "mdi:radiator"
+      },
+      "stream_diheatsinktrel": {
+        "default": "mdi:radiator"
+      },
+      "stream_diheatsinktrer": {
+        "default": "mdi:radiator"
+      },
+      "stream_dimotorcurrentf": {
+        "default": "mdi:current-dc"
+      },
+      "stream_dimotorcurrentr": {
+        "default": "mdi:current-dc"
+      },
+      "stream_dimotorcurrentrel": {
+        "default": "mdi:current-dc"
+      },
+      "stream_dimotorcurrentrer": {
+        "default": "mdi:current-dc"
+      },
+      "stream_distatef": {
+        "default": "mdi:car-info"
+      },
+      "stream_distater": {
+        "default": "mdi:car-info"
+      },
+      "stream_distaterel": {
+        "default": "mdi:car-info"
+      },
+      "stream_distaterer": {
+        "default": "mdi:car-info"
+      },
+      "stream_distatortempf": {
+        "default": "mdi:coolant-temperature"
+      },
+      "stream_distatortempr": {
+        "default": "mdi:coolant-temperature"
+      },
+      "stream_distatortemprel": {
+        "default": "mdi:coolant-temperature"
+      },
+      "stream_distatortemprer": {
+        "default": "mdi:coolant-temperature"
+      },
+      "stream_divbatf": {
+        "default": "mdi:battery-check"
+      },
+      "stream_divbatr": {
+        "default": "mdi:battery-check"
+      },
+      "stream_divbatrel": {
+        "default": "mdi:battery-check"
+      },
+      "stream_divbatrer": {
+        "default": "mdi:battery-check"
+      },
+      "stream_doorstate": {
+        "default": "mdi:car-door"
+      },
+      "stream_driverail": {
+        "default": "mdi:flash-triangle"
+      },
+      "stream_driverseatbelt": {
+        "default": "mdi:seatbelt"
+      },
+      "stream_driverseatoccupied": {
+        "default": "mdi:car-seat"
+      },
+      "stream_emergencylanedepartureavoidance": {
+        "default": "mdi:road-variant"
+      },
+      "stream_energyremaining": {
+        "default": "mdi:lightning-bolt"
+      },
+      "stream_fastchargerpresent": {
+        "default": "mdi:ev-plug-tesla"
+      },
+      "stream_forwardcollisionwarning": {
+        "default": "mdi:car-multiple"
+      },
+      "stream_gpsstate": {
+        "default": "mdi:crosshairs-gps"
+      },
+      "stream_guestmodeenabled": {
+        "default": "mdi:account-clock"
+      },
+      "stream_guestmodemobileaccessstate": {
+        "default": "mdi:account-clock"
+      },
+      "stream_hvil": {
+        "default": "mdi:flash-triangle"
+      },
+      "stream_isolationresistance": {
+        "default": "mdi:resistor"
+      },
+      "stream_lanedepartureavoidance": {
+        "default": "mdi:road-variant"
+      },
+      "stream_lateralacceleration": {
+        "default": "mdi:axis-arrow"
+      },
+      "stream_longitudinalacceleration": {
+        "default": "mdi:axis-arrow"
+      },
+      "stream_moduletempmax": {
+        "default": "mdi:battery-arrow-up"
+      },
+      "stream_moduletempmin": {
+        "default": "mdi:battery-arrow-down"
+      },
+      "stream_notenoughpowertoheat": {
+        "default": "mdi:radiator-off"
+      },
+      "stream_numbrickvoltagemax": {
+        "default": "mdi:battery-plus"
+      },
+      "stream_numbrickvoltagemin": {
+        "default": "mdi:battery-minus"
+      },
+      "stream_nummoduletempmax": {
+        "default": "mdi:battery-arrow-up"
+      },
+      "stream_nummoduletempmin": {
+        "default": "mdi:battery-arrow-down"
+      },
+      "stream_originlocation": {
+        "default": "mdi:map-marker"
+      },
+      "stream_packcurrent": {
+        "default": "mdi:battery-clock"
+      },
+      "stream_packvoltage": {
+        "default": "mdi:sine-wave"
+      },
+      "stream_pairedphonekeyandkeyfobqty": {
+        "default": "mdi:cellphone-key"
+      },
+      "stream_passengerseatbelt": {
+        "default": "mdi:seatbelt"
+      },
+      "stream_pintodriveenabled": {
+        "default": "mdi:car-key"
+      },
+      "stream_ratedrange": {
+        "default": "mdi:arrow-left-right"
+      },
+      "stream_routelastupdated": {
+        "default": "mdi:map-clock"
+      },
+      "stream_routeline": {
+        "default": "mdi:map"
+      },
+      "stream_soc": {
+        "default": "mdi:battery"
+      },
+      "stream_speedlimitwarning": {
+        "default": "mdi:car-speed-limiter"
       }
     },
     "switch": {

--- a/custom_components/teslemetry/translations/en.json
+++ b/custom_components/teslemetry/translations/en.json
@@ -69,28 +69,28 @@
         "name": "Storm watch active"
       },
       "stream_automaticblindspotcamera": {
-        "name": "AutomaticBlindSpotCamera"
+        "name": "Automatic Blind Spot Camera"
       },
       "stream_automaticemergencybrakingoff": {
-        "name": "AutomaticEmergencyBrakingOff"
+        "name": "Automatic Emergency Braking Off"
       },
       "stream_blindspotcollisionwarningchime": {
-        "name": "BlindSpotCollisionWarningChime"
+        "name": "Blind Spot Collision Warning Chime"
       },
       "stream_bmsfullchargecomplete": {
-        "name": "BmsFullchargecomplete"
+        "name": "BMS Full Charge"
       },
       "stream_brakepedal": {
-        "name": "BrakePedal"
+        "name": "Brake Pedal"
       },
       "stream_chargeenablerequest": {
-        "name": "ChargeEnableRequest"
+        "name": "Charge Enable Request"
       },
       "stream_chargeportcoldweathermode": {
-        "name": "ChargePortColdWeatherMode"
+        "name": "Charge Port Cold Weather Mode"
       },
       "stream_servicemode": {
-        "name": "ServiceMode"
+        "name": "Service Mode"
       },
       "vehicle_state_dashcam_state": {
         "name": "Dashcam"
@@ -489,265 +489,265 @@
         "name": "Solar power"
       },
       "stream_bmsstate": {
-        "name": "BMSState"
+        "name": "BMS State"
       },
       "stream_brakepedalpos": {
-        "name": "BrakePedalPos"
+        "name": "Brake Pedal Position"
       },
       "stream_brickvoltagemax": {
-        "name": "BrickVoltageMax"
+        "name": "Brick Voltage Max"
       },
       "stream_brickvoltagemin": {
-        "name": "BrickVoltageMin"
+        "name": "Brick Voltage Min"
       },
       "stream_cartype": {
-        "name": "CarType"
+        "name": "Car Type"
       },
       "stream_chargecurrentrequestmax": {
-        "name": "ChargeCurrentRequestMax"
+        "name": "Charge Current Request Max"
       },
       "stream_chargeport": {
-        "name": "ChargePort"
+        "name": "Charge Port"
       },
       "stream_cruisefollowdistance": {
-        "name": "CruiseFollowDistance"
+        "name": "Cruise Distance"
       },
       "stream_cruisesetspeed": {
-        "name": "CruiseSetSpeed"
+        "name": "Cruise Speed"
       },
       "stream_cruisestate": {
-        "name": "CruiseState"
+        "name": "Cruise State"
       },
       "stream_dcchargingenergyin": {
-        "name": "DCChargingEnergyIn"
+        "name": "DC Charging In"
       },
       "stream_dcchargingpower": {
-        "name": "DCChargingPower"
+        "name": "DC Charging Power"
       },
       "stream_dcdcenable": {
-        "name": "DCDCEnable"
+        "name": "DCDC Enable"
       },
       "stream_destinationlocation": {
-        "name": "DestinationLocation"
+        "name": "Destination Location"
       },
       "stream_diaxlespeedf": {
-        "name": "DiAxleSpeedF"
+        "name": "Front DU Axle Speed"
       },
       "stream_diaxlespeedr": {
-        "name": "DiAxleSpeedR"
+        "name": "Rear DU Axle Speed"
       },
       "stream_diaxlespeedrel": {
-        "name": "DiAxleSpeedREL"
+        "name": "Rear Left DU Axle Speed "
       },
       "stream_diaxlespeedrer": {
-        "name": "DiAxleSpeedRER"
+        "name": "Rear Right DU Axle Speed"
       },
       "stream_diheatsinktf": {
-        "name": "DiHeatsinkTF"
+        "name": "Front DI Heatsink Temperature"
       },
       "stream_diheatsinktr": {
-        "name": "DiHeatsinkTR"
+        "name": "Rear DI Heatsink Temperature"
       },
       "stream_diheatsinktrel": {
-        "name": "DiHeatsinkTREL"
+        "name": "Rear Left DI Heatsink Temperature"
       },
       "stream_diheatsinktrer": {
-        "name": "DiHeatsinkTRER"
+        "name": "Rear Right DI Heatsink Temperature"
       },
       "stream_dimotorcurrentf": {
-        "name": "DiMotorCurrentF"
+        "name": "Front DI Current"
       },
       "stream_dimotorcurrentr": {
-        "name": "DiMotorCurrentR"
+        "name": "Rear DI Current"
       },
       "stream_dimotorcurrentrel": {
-        "name": "DiMotorCurrentREL"
+        "name": "Rear Left DI Current"
       },
       "stream_dimotorcurrentrer": {
-        "name": "DiMotorCurrentRER"
+        "name": "Rear Right DI Current"
       },
       "stream_dislavetorquecmd": {
         "name": "DiSlaveTorqueCmd"
       },
       "stream_distatef": {
-        "name": "DiStateF"
+        "name": "Front DI State"
       },
       "stream_distater": {
-        "name": "DiStateR"
+        "name": "Rear DI State"
       },
       "stream_distaterel": {
-        "name": "DiStateREL"
+        "name": "Rear Left DI State"
       },
       "stream_distaterer": {
-        "name": "DiStateRER"
+        "name": "Rear Right DI State"
       },
       "stream_distatortempf": {
-        "name": "DiStatorTempF"
+        "name": "Front DU Stator Temperature"
       },
       "stream_distatortempr": {
-        "name": "DiStatorTempR"
+        "name": "Rear DU Stator Temperature"
       },
       "stream_distatortemprel": {
-        "name": "DiStatorTempREL"
+        "name": "Rear Left DU Stator Temperature"
       },
       "stream_distatortemprer": {
-        "name": "DiStatorTempRER"
+        "name": "Rear Right DU Stator Temperature"
       },
       "stream_ditorqueactualf": {
-        "name": "DiTorqueActualF"
+        "name": "Front DU Torque"
       },
       "stream_ditorqueactualr": {
-        "name": "DiTorqueActualR"
+        "name": "Rear DU Torque"
       },
       "stream_ditorqueactualrel": {
-        "name": "DiTorqueActualREL"
+        "name": "Rear Left DU Torque"
       },
       "stream_ditorqueactualrer": {
-        "name": "DiTorqueActualRER"
+        "name": "Rear Right DU Torque"
       },
       "stream_ditorquemotor": {
         "name": "DiTorquemotor"
       },
       "stream_divbatf": {
-        "name": "DiVBatF"
+        "name": "Front DI Voltage"
       },
       "stream_divbatr": {
-        "name": "DiVBatR"
+        "name": "Rear DI Voltage"
       },
       "stream_divbatrel": {
-        "name": "DiVBatREL"
+        "name": "Rear Left DI Voltage"
       },
       "stream_divbatrer": {
-        "name": "DiVBatRER"
+        "name": "Rear Right DI Voltage"
       },
       "stream_doorstate": {
-        "name": "DoorState"
+        "name": "Door State"
       },
       "stream_driverail": {
-        "name": "DriveRail"
+        "name": "Drive Rail"
       },
       "stream_driverseatbelt": {
-        "name": "DriverSeatBelt"
+        "name": "Driver Seat Belt"
       },
       "stream_driverseatoccupied": {
-        "name": "DriverSeatOccupied"
+        "name": "Driver Seat Occupied"
       },
       "stream_emergencylanedepartureavoidance": {
-        "name": "EmergencyLaneDepartureAvoidance"
+        "name": "Emergency Lane Departure Avoidance"
       },
       "stream_energyremaining": {
-        "name": "EnergyRemaining"
+        "name": "Pack Remaining"
       },
       "stream_fastchargerpresent": {
-        "name": "FastChargerPresent"
+        "name": "Fast Charger Present"
       },
       "stream_forwardcollisionwarning": {
-        "name": "ForwardCollisionWarning"
+        "name": "Forward Collision Warning"
       },
       "stream_gpsheading": {
-        "name": "GpsHeading"
+        "name": "Heading"
       },
       "stream_gpsstate": {
-        "name": "GpsState"
+        "name": "GPS State"
       },
       "stream_guestmodeenabled": {
-        "name": "GuestModeEnabled"
+        "name": "Guest Mode Enabled"
       },
       "stream_guestmodemobileaccessstate": {
-        "name": "GuestModeMobileAccessState"
+        "name": "Guest Mode State"
       },
       "stream_hvil": {
-        "name": "Hvil"
+        "name": "HVIL"
       },
       "stream_isolationresistance": {
-        "name": "IsolationResistance"
+        "name": "Isolation Resistance"
       },
       "stream_lanedepartureavoidance": {
-        "name": "LaneDepartureAvoidance"
+        "name": "Lane Departure Avoidance"
       },
       "stream_lateralacceleration": {
-        "name": "LateralAcceleration"
+        "name": "Lateral Acceleration"
       },
       "stream_lifetimeenergygainedregen": {
-        "name": "LifetimeEnergyGainedRegen"
+        "name": "Lifetime Energy Gained Regen"
       },
       "stream_lifetimeenergyused": {
-        "name": "LifetimeEnergyUsed"
+        "name": "Lifetime Energy Used"
       },
       "stream_lifetimeenergyuseddrive": {
-        "name": "LifetimeEnergyUsedDrive"
+        "name": "Lifetime Energy Used Drive"
       },
       "stream_longitudinalacceleration": {
-        "name": "LongitudinalAcceleration"
+        "name": "Longitudinal Acceleration"
       },
       "stream_moduletempmax": {
-        "name": "ModuleTempMax"
+        "name": "Module Temperature Maximum"
       },
       "stream_moduletempmin": {
-        "name": "ModuleTempMin"
+        "name": "Module Temperature Minimum"
       },
       "stream_notenoughpowertoheat": {
-        "name": "NotEnoughPowerToHeat"
+        "name": "Not Enough Power To Heat"
       },
       "stream_numbrickvoltagemax": {
-        "name": "NumBrickVoltageMax"
+        "name": "Brick Number Voltage Maximum"
       },
       "stream_numbrickvoltagemin": {
-        "name": "NumBrickVoltageMin"
+        "name": "Brick Number Voltage Minimum"
       },
       "stream_nummoduletempmax": {
-        "name": "NumModuleTempMax"
+        "name": "Module Number Temperature Maximum"
       },
       "stream_nummoduletempmin": {
-        "name": "NumModuleTempMin"
+        "name": "Module Number Temperature Minimum"
       },
       "stream_originlocation": {
-        "name": "OriginLocation"
+        "name": "Origin Location"
       },
       "stream_packcurrent": {
-        "name": "PackCurrent"
+        "name": "Pack Current"
       },
       "stream_packvoltage": {
-        "name": "PackVoltage"
+        "name": "Pack Voltage"
       },
       "stream_pairedphonekeyandkeyfobqty": {
-        "name": "PairedPhoneKeyAndKeyFobQty"
+        "name": "Number of paired Keys"
       },
       "stream_passengerseatbelt": {
-        "name": "PassengerSeatBelt"
+        "name": "Passenger Seat Belt"
       },
       "stream_pedalposition": {
-        "name": "PedalPosition"
+        "name": "Pedal Position"
       },
       "stream_pintodriveenabled": {
-        "name": "PinToDriveEnabled"
+        "name": "Pin To Drive Enabled"
       },
       "stream_ratedrange": {
-        "name": "RatedRange"
+        "name": "Rated Range"
       },
       "stream_routelastupdated": {
-        "name": "RouteLastUpdated"
+        "name": "Route Last Updated"
       },
       "stream_routeline": {
-        "name": "RouteLine"
+        "name": "Route Line"
       },
       "stream_sentrymode": {
         "name": "Sentry Mode"
       },
       "stream_soc": {
-        "name": "Soc"
+        "name": "SoC"
       },
       "stream_speedlimitwarning": {
-        "name": "SpeedLimitWarning"
+        "name": "Speed Limit Warning"
       },
       "stream_superchargersessiontripplanner": {
-        "name": "SuperchargerSessionTripPlanner"
+        "name": "Supercharger Session Trip Planner"
       },
       "stream_trim": {
         "name": "Trim"
       },
       "stream_vehiclename": {
-        "name": "VehicleName"
+        "name": "Vehicle Name"
       },
       "stream_version": {
         "name": "Version"


### PR DESCRIPTION
This PR adds names and icons on streaming fields providing some more detail on what fields are.

It will be good if I can know if naming can be unified like capitalizing (or not) every word.
Also know what makes the most sense to maintain coherence (indicate or not DI + DU on drive unit fields and unify battery naming like module, pack, brick)