### PR TITLE
Improvements to sensors, translations and icons

### DIFF
--- a/custom_components/teslemetry/icons.json
+++ b/custom_components/teslemetry/icons.json
@@ -7,6 +7,12 @@
           "on": "mdi:hvac"
         }
       },
+      "charge_state_preconditioning_enabled": {
+        "state": {
+          "off": "mdi:hvac-off",
+          "on": "mdi:hvac"
+        }
+      },
       "storm_mode_active": {
         "state": {
           "off": "mdi:weather-sunny",
@@ -42,17 +48,57 @@
           "off": "mdi:tire",
           "on": "mdi:car-tire-alert"
         }
+      },
+      "vehicle_state_dashcam_state": {
+        "state": {
+          "off": "mdi:camera-off",
+          "on": "mdi:camera"
+        }
+      },
+      "vehicle_state_df": {
+        "state": {
+          "off": "mdi:car-door-lock",
+          "on": "mdi:car-door-lock-open"
+        }
+      },
+      "vehicle_state_dr": {
+        "state": {
+          "off": "mdi:car-door-lock",
+          "on": "mdi:car-door-lock-open"
+        }
+      },
+      "vehicle_state_pf": {
+        "state": {
+          "off": "mdi:car-door-lock",
+          "on": "mdi:car-door-lock-open"
+        }
+      },
+      "vehicle_state_pr": {
+        "state": {
+          "off": "mdi:car-door-lock",
+          "on": "mdi:car-door-lock-open"
+        }
+      },
+      "charge_state_conn_charge_cable": {
+        "state": {
+          "default": "mdi:ev-plug-tesla"
+        }
+      },
+      "charge_state_scheduled_charging_mode": {
+        "state": {
+          "default": "mdi:battery-clock"
+        }
       }
     },
     "button": {
       "boombox": {
-        "default": "mdi:volume-high"
+        "default": "mdi:boombox"
       },
       "enable_keyless_driving": {
         "default": "mdi:car-key"
       },
       "flash_lights": {
-        "default": "mdi:flashlight"
+        "default": "mdi:car-light-high"
       },
       "homelink": {
         "default": "mdi:garage"
@@ -90,6 +136,12 @@
     "cover": {
       "charge_state_charge_port_door_open": {
         "default": "mdi:ev-plug-tesla"
+      },
+      "vehicle_state_ft": {
+        "default": "mdi:car-door-lock-open"
+      },
+      "vehicle_state_rt": {
+        "default": "mdi:car-door-lock-open"
       }
     },
     "device_tracker": {
@@ -196,7 +248,7 @@
       "charge_state_charging_state": {
         "default": "mdi:ev-station",
         "state": {
-          "disconnected": "mdi:connection",
+          "disconnected": "mdi:power-plug-outline",
           "no_power": "mdi:power-plug-off-outline",
           "starting": "mdi:play-circle",
           "stopped": "mdi:stop-circle"
@@ -217,10 +269,10 @@
       "energy_left": {
         "default": "mdi:battery"
       },
-      "event_alerts": {
+      "alerts": {
         "default": "mdi:chat-alert"
       },
-      "event_errors": {
+      "errors": {
         "default": "mdi:alert"
       },
       "generator_power": {
@@ -262,7 +314,7 @@
       "wall_connector_state": {
         "default": "mdi:ev-station"
       },
-      "stream_sentrymode": {
+      "sentry_mode": {
         "default": "mdi:shield-car"
       },
       "total_home_usage": {
@@ -286,215 +338,215 @@
       "solar_energy_exported": {
         "default": "mdi:solar-power-variant"
       },
-      "stream_bmsstate": {
+      "bms_state": {
         "default": "mdi:battery-sync"
       },
-      "stream_brakepedalpos": {
+      "brake_pedal_position": {
         "default": "mdi:car-brake-alert"
       },
-      "stream_brickvoltagemax": {
+      "brick_voltage_max": {
         "default": "mdi:battery-arrow-up"
       },
-      "stream_brickvoltagemin": {
+      "brick_voltage_min": {
         "default": "mdi:battery-arrow-down"
       },
-      "stream_cartype": {
+      "car_type": {
         "default": "mdi:car"
       },
-      "stream_chargeport": {
+      "charge_port": {
         "default": "mdi:ev-plug-tesla"
       },
-      "stream_cruisefollowdistance": {
+      "cruise_follow_distance": {
         "default": "mdi:car-cruise-control"
       },
-      "stream_cruisesetspeed": {
+      "cruise_set_speed": {
         "default": "mdi:car-cruise-control"
       },
-      "stream_dcchargingenergyin": {
+      "dc_charging_engery_in": {
         "default": "mdi:lightning-bolt"
       },
-      "stream_dcchargingpower": {
+      "dc_charging_power": {
         "default": "mdi:flash"
       },
-      "stream_dcdcenable": {
+      "dc_dc_enable": {
         "default": "mdi:flash-triangle"
       },
-      "stream_destinationlocation": {
-        "default": "mdi:map-marker"
-      },
-      "stream_diaxlespeedf": {
+      "di_axle_speed_front": {
         "default": "mdi:speedometer"
       },
-      "stream_diaxlespeedr": {
+      "di_axle_speed_rear": {
         "default": "mdi:speedometer"
       },
-      "stream_diaxlespeedrel": {
+      "di_axle_speed_rear_left": {
         "default": "mdi:speedometer"
       },
-      "stream_diaxlespeedrer": {
+      "di_axle_speed_rear_right": {
         "default": "mdi:speedometer"
       },
-      "stream_diheatsinktf": {
+      "di_heatsink_temp_front": {
         "default": "mdi:radiator"
       },
-      "stream_diheatsinktr": {
+      "di_heatsink_temp_rear": {
         "default": "mdi:radiator"
       },
-      "stream_diheatsinktrel": {
+      "di_heatsink_temp_rear_left": {
         "default": "mdi:radiator"
       },
-      "stream_diheatsinktrer": {
+      "di_heatsink_temp_rear_right": {
         "default": "mdi:radiator"
       },
-      "stream_dimotorcurrentf": {
+      "di_motor_current_front": {
         "default": "mdi:current-dc"
       },
-      "stream_dimotorcurrentr": {
+      "di_motor_current_rear": {
         "default": "mdi:current-dc"
       },
-      "stream_dimotorcurrentrel": {
+      "di_motor_current_rear_left": {
         "default": "mdi:current-dc"
       },
-      "stream_dimotorcurrentrer": {
+      "di_motor_current_rear_right": {
         "default": "mdi:current-dc"
       },
-      "stream_distatef": {
+      "di_state_front": {
         "default": "mdi:car-info"
       },
-      "stream_distater": {
+      "di_state_rear": {
         "default": "mdi:car-info"
       },
-      "stream_distaterel": {
+      "di_state_rear_left": {
         "default": "mdi:car-info"
       },
-      "stream_distaterer": {
+      "di_state_rear_right": {
         "default": "mdi:car-info"
       },
-      "stream_distatortempf": {
+      "di_stator_temp_front": {
         "default": "mdi:coolant-temperature"
       },
-      "stream_distatortempr": {
+      "di_stator_temp_rear": {
         "default": "mdi:coolant-temperature"
       },
-      "stream_distatortemprel": {
+      "di_stator_temp_rear_left": {
         "default": "mdi:coolant-temperature"
       },
-      "stream_distatortemprer": {
+      "di_stator_temp_rear_right": {
         "default": "mdi:coolant-temperature"
       },
-      "stream_divbatf": {
+      "di_voltage_battery_front": {
         "default": "mdi:battery-check"
       },
-      "stream_divbatr": {
+      "di_voltage_battery_rear": {
         "default": "mdi:battery-check"
       },
-      "stream_divbatrel": {
+      "di_voltage_battery_rear_left": {
         "default": "mdi:battery-check"
       },
-      "stream_divbatrer": {
+      "di_voltage_battery_rear_right": {
         "default": "mdi:battery-check"
       },
-      "stream_doorstate": {
-        "default": "mdi:car-door"
-      },
-      "stream_driverail": {
+      "drive_rail": {
         "default": "mdi:flash-triangle"
       },
-      "stream_driverseatbelt": {
+      "driver_seat_belt": {
         "default": "mdi:seatbelt"
       },
-      "stream_driverseatoccupied": {
+      "driver_seat_occupied": {
         "default": "mdi:car-seat"
       },
-      "stream_emergencylanedepartureavoidance": {
-        "default": "mdi:road-variant"
-      },
-      "stream_energyremaining": {
+      "energy_remaining": {
         "default": "mdi:lightning-bolt"
       },
-      "stream_fastchargerpresent": {
+      "fast_charger_present": {
         "default": "mdi:ev-plug-tesla"
       },
-      "stream_forwardcollisionwarning": {
+      "forward_collision_warning": {
         "default": "mdi:car-multiple"
       },
-      "stream_gpsstate": {
+      "gps_state": {
         "default": "mdi:crosshairs-gps"
       },
-      "stream_guestmodeenabled": {
+      "guest_mode_enabled": {
         "default": "mdi:account-clock"
       },
-      "stream_guestmodemobileaccessstate": {
+      "guest_mode_mobile_access_state": {
         "default": "mdi:account-clock"
       },
-      "stream_hvil": {
+      "hvil": {
         "default": "mdi:flash-triangle"
       },
-      "stream_isolationresistance": {
+      "isolation_resistance": {
         "default": "mdi:resistor"
       },
-      "stream_lanedepartureavoidance": {
+      "emergency_lane_departure_avoidance": {
         "default": "mdi:road-variant"
       },
-      "stream_lateralacceleration": {
+      "lane_departure_avoidance": {
+        "default": "mdi:road-variant"
+      },
+      "lateral_acceleration": {
         "default": "mdi:axis-arrow"
       },
-      "stream_longitudinalacceleration": {
+      "longitudinal_acceleration": {
         "default": "mdi:axis-arrow"
       },
-      "stream_moduletempmax": {
+      "module_temp_max": {
         "default": "mdi:battery-arrow-up"
       },
-      "stream_moduletempmin": {
+      "module_temp_min": {
         "default": "mdi:battery-arrow-down"
       },
-      "stream_notenoughpowertoheat": {
+      "no_enough_power_to_heat": {
         "default": "mdi:radiator-off"
       },
-      "stream_numbrickvoltagemax": {
+      "brick_number_voltage_max": {
         "default": "mdi:battery-plus"
       },
-      "stream_numbrickvoltagemin": {
+      "brick_number_voltage_min": {
         "default": "mdi:battery-minus"
       },
-      "stream_nummoduletempmax": {
+      "module_number_temp_max": {
         "default": "mdi:battery-arrow-up"
       },
-      "stream_nummoduletempmin": {
+      "module_number_temp_min": {
         "default": "mdi:battery-arrow-down"
       },
-      "stream_originlocation": {
-        "default": "mdi:map-marker"
-      },
-      "stream_packcurrent": {
+      "pack_current": {
         "default": "mdi:battery-clock"
       },
-      "stream_packvoltage": {
+      "pack_voltage": {
         "default": "mdi:sine-wave"
       },
-      "stream_pairedphonekeyandkeyfobqty": {
+      "paired_key_quantity": {
         "default": "mdi:cellphone-key"
       },
-      "stream_passengerseatbelt": {
+      "passenger_seat_belt": {
         "default": "mdi:seatbelt"
       },
-      "stream_pintodriveenabled": {
+      "pin_to_drive_enabled": {
         "default": "mdi:car-key"
       },
-      "stream_ratedrange": {
+      "rated_range": {
         "default": "mdi:arrow-left-right"
       },
-      "stream_routelastupdated": {
+      "route_last_updated": {
         "default": "mdi:map-clock"
       },
-      "stream_routeline": {
-        "default": "mdi:map"
-      },
-      "stream_soc": {
-        "default": "mdi:battery"
-      },
-      "stream_speedlimitwarning": {
+      "speed_limit_warning": {
         "default": "mdi:car-speed-limiter"
+      },
+     "vehicle_config_exterior_color": {
+        "default": "mdi:palette"
+      },
+      "charge_state_conn_charge_cable": {
+        "default": "mdi:ev-plug-tesla"
+      },
+      "charge_state_fast_charger_type": {
+        "default": "mdi:ev-plug-tesla"
+      },
+      "center_display": {
+        "default": "mdi:monitor-eye"
+      },
+      "drive_state_active_route_traffic_minutes_delay": {
+        "default": "mdi:traffic-light"
       }
     },
     "switch": {

--- a/custom_components/teslemetry/sensor.py
+++ b/custom_components/teslemetry/sensor.py
@@ -111,7 +111,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
     TeslemetrySensorEntityDescription(
         key="charge_state_usable_battery_level",
         polling=True,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
@@ -140,7 +139,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
     TeslemetrySensorEntityDescription(
         key="charge_state_charger_voltage",
         polling=True,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
@@ -150,7 +148,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="charge_state_charger_actual_current",
         polling=True,
         streaming_key=Signal.CHARGE_AMPS,
-
         suggested_display_precision=0,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
@@ -160,7 +157,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
     TeslemetrySensorEntityDescription(
         key="charge_state_charge_rate",
         polling=True,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfSpeed.MILES_PER_HOUR,
         device_class=SensorDeviceClass.SPEED,
@@ -170,7 +166,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="charge_state_conn_charge_cable",
         polling=True,
         streaming_key=Signal.CHARGING_CABLE_TYPE,
-
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
@@ -178,14 +173,12 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="charge_state_fast_charger_type",
         polling=True,
         streaming_key=Signal.FAST_CHARGER_TYPE,
-
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
     TeslemetrySensorEntityDescription(
         key="charge_state_battery_range",
         polling=True,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfLength.MILES,
         device_class=SensorDeviceClass.DISTANCE,
@@ -196,7 +189,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="charge_state_est_battery_range",
         polling=True,
         streaming_key=Signal.EST_BATTERY_RANGE,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfLength.MILES,
         device_class=SensorDeviceClass.DISTANCE,
@@ -207,7 +199,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="charge_state_ideal_battery_range",
         polling=True,
         streaming_key=Signal.IDEAL_BATTERY_RANGE,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfLength.MILES,
         device_class=SensorDeviceClass.DISTANCE,
@@ -219,18 +210,16 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         streaming_key=Signal.VEHICLE_SPEED,
         polling=True,
         polling_value_fn=lambda value: value or 0,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfSpeed.MILES_PER_HOUR,
         device_class=SensorDeviceClass.SPEED,
         entity_registry_enabled_default=False,
-
+        suggested_display_precision=0,
     ),
     TeslemetrySensorEntityDescription(
         key="drive_state_power",
         polling=True,
         polling_value_fn=lambda value: value or 0,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         device_class=SensorDeviceClass.POWER,
@@ -252,7 +241,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="vehicle_state_odometer",
         polling=True,
         streaming_key=Signal.ODOMETER,
-
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfLength.MILES,
         device_class=SensorDeviceClass.DISTANCE,
@@ -264,12 +252,10 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="vehicle_state_tpms_pressure_fl",
         polling=True,
         streaming_key=Signal.TPMS_PRESSURE_FL,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPressure.BAR,
-        suggested_unit_of_measurement=UnitOfPressure.PSI,
         device_class=SensorDeviceClass.PRESSURE,
-        suggested_display_precision=1,
+        suggested_display_precision=2,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
@@ -277,12 +263,10 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="vehicle_state_tpms_pressure_fr",
         polling=True,
         streaming_key=Signal.TPMS_PRESSURE_FR,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPressure.BAR,
-        suggested_unit_of_measurement=UnitOfPressure.PSI,
         device_class=SensorDeviceClass.PRESSURE,
-        suggested_display_precision=1,
+        suggested_display_precision=2,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
@@ -290,12 +274,10 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="vehicle_state_tpms_pressure_rl",
         polling=True,
         streaming_key=Signal.TPMS_PRESSURE_RL,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPressure.BAR,
-        suggested_unit_of_measurement=UnitOfPressure.PSI,
         device_class=SensorDeviceClass.PRESSURE,
-        suggested_display_precision=1,
+        suggested_display_precision=2,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
@@ -303,12 +285,10 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="vehicle_state_tpms_pressure_rr",
         polling=True,
         streaming_key=Signal.TPMS_PRESSURE_RR,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPressure.BAR,
-        suggested_unit_of_measurement=UnitOfPressure.PSI,
         device_class=SensorDeviceClass.PRESSURE,
-        suggested_display_precision=1,
+        suggested_display_precision=2,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
@@ -316,7 +296,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="climate_state_inside_temp",
         polling=True,
         streaming_key=Signal.INSIDE_TEMP,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -326,7 +305,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="climate_state_outside_temp",
         polling=True,
         streaming_key=Signal.OUTSIDE_TEMP,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -335,7 +313,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
     TeslemetrySensorEntityDescription(
         key="climate_state_driver_temp_setting",
         polling=True,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -346,7 +323,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
     TeslemetrySensorEntityDescription(
         key="climate_state_passenger_temp_setting",
         polling=True,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -358,7 +334,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="drive_state_active_route_traffic_minutes_delay",
         polling=True,
         streaming_key=Signal.ROUTE_TRAFFIC_MINUTES_DELAY,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTime.MINUTES,
         device_class=SensorDeviceClass.DURATION,
@@ -368,7 +343,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="drive_state_active_route_energy_at_arrival",
         polling=True,
         streaming_key=Signal.EXPECTED_ENERGY_PERCENT_AT_TRIP_ARRIVAL,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
@@ -380,7 +354,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="drive_state_active_route_miles_to_arrival",
         polling=True,
         streaming_key=Signal.MILES_TO_ARRIVAL,
-
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfLength.MILES,
         device_class=SensorDeviceClass.DISTANCE,
@@ -391,7 +364,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         polling=True,
         streaming_key=Signal.TIME_TO_FULL_CHARGE,
         polling_available_fn=lambda x: x is not None and float(x) > 0,
-
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.HOURS,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -401,7 +373,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="drive_state_active_route_minutes_to_arrival",
         polling=True,
         streaming_key=Signal.MINUTES_TO_ARRIVAL,
-
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.MINUTES,
     ),
@@ -411,7 +382,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         streaming_key=Signal.TPMS_LAST_SEEN_PRESSURE_TIME_FL,
         polling_value_fn=lambda x: dt_util.utc_from_timestamp(int(x)),
         streaming_value_fn=lambda x: dt_util.utc_from_timestamp(int(x)),
-
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_registry_enabled_default=False,
     ),
@@ -421,7 +391,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         streaming_key=Signal.TPMS_LAST_SEEN_PRESSURE_TIME_FR,
         polling_value_fn=lambda x: dt_util.utc_from_timestamp(int(x)),
         streaming_value_fn=lambda x: dt_util.utc_from_timestamp(int(x)),
-
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_registry_enabled_default=False,
     ),
@@ -431,7 +400,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         streaming_key=Signal.TPMS_LAST_SEEN_PRESSURE_TIME_RL,
         polling_value_fn=lambda x: dt_util.utc_from_timestamp(int(x)),
         streaming_value_fn=lambda x: dt_util.utc_from_timestamp(int(x)),
-
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_registry_enabled_default=False,
     ),
@@ -441,7 +409,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         streaming_key=Signal.TPMS_LAST_SEEN_PRESSURE_TIME_RR,
         polling_value_fn=lambda x: dt_util.utc_from_timestamp(int(x)),
         streaming_value_fn=lambda x: dt_util.utc_from_timestamp(int(x)),
-
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_registry_enabled_default=False,
     ),
@@ -467,7 +434,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         polling_value_fn=lambda x: dt_util.utc_from_timestamp(int(x)),
         streaming_key=Signal.SCHEDULED_CHARGING_START_TIME,
         streaming_value_fn=lambda x: dt_util.utc_from_timestamp(int(x)),
-
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_registry_enabled_default=False,
     ),
@@ -477,7 +443,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         polling_value_fn=lambda x: dt_util.utc_from_timestamp(int(x)),
         streaming_key=Signal.SCHEDULED_DEPARTURE_TIME,
         streaming_value_fn=lambda x: dt_util.utc_from_timestamp(int(x)),
-
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_registry_enabled_default=False,
     ),
@@ -485,19 +450,16 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="vehicle_config_exterior_color",
         polling=True,
         streaming_key=Signal.EXTERIOR_COLOR,
-
         entity_registry_enabled_default=False,
     ),
     TeslemetrySensorEntityDescription(
         key="bms_state",
         streaming_key=Signal.BMS_STATE,
-
         entity_registry_enabled_default=False,
     ),
     TeslemetrySensorEntityDescription(
         key="brake_pedal_position",
         streaming_key=Signal.BRAKE_PEDAL_POS,
-
         native_unit_of_measurement=PERCENTAGE,
         entity_registry_enabled_default=False,
     ),
@@ -507,7 +469,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=2,
+        suggested_display_precision=3,
         entity_registry_enabled_default=False,
     ),
     TeslemetrySensorEntityDescription(
@@ -516,7 +478,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=2,
+        suggested_display_precision=3,
         entity_registry_enabled_default=False,
     ),
     TeslemetrySensorEntityDescription(
@@ -566,6 +528,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.KILO_WATT, #Unconfirmed
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
+        suggested_display_precision=2,
     ),
     TeslemetrySensorEntityDescription(
         key="di_axle_speed_front",
@@ -593,49 +556,78 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
     TeslemetrySensorEntityDescription(
         key="di_heatsink_temp_front",
         streaming_key=Signal.DI_HEATSINK_TF,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        suggested_display_precision=1,
+        streaming_value_fn=lambda x: float(x),
         entity_registry_enabled_default=False,
-        suggested_display_precision=2,
     ),
     TeslemetrySensorEntityDescription(
         key="di_heatsink_temp_rear",
         streaming_key=Signal.DI_HEATSINK_TR,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        suggested_display_precision=1,
+        streaming_value_fn=lambda x: float(x),
         entity_registry_enabled_default=False,
-        suggested_display_precision=2,
     ),
     TeslemetrySensorEntityDescription(
         key="di_heatsink_temp_rear_left",
         streaming_key=Signal.DI_HEATSINK_TREL,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        suggested_display_precision=1,
+        streaming_value_fn=lambda x: float(x),
         entity_registry_enabled_default=False,
-        suggested_display_precision=2,
     ),
     TeslemetrySensorEntityDescription(
         key="di_heatsink_temp_rear_right",
         streaming_key=Signal.DI_HEATSINK_TRER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        suggested_display_precision=1,
+        streaming_value_fn=lambda x: float(x),
         entity_registry_enabled_default=False,
-        suggested_display_precision=2,
     ),
     TeslemetrySensorEntityDescription(
         key="di_motor_current_front",
         streaming_key=Signal.DI_MOTOR_CURRENT_F,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
         suggested_display_precision=2,
     ),
     TeslemetrySensorEntityDescription(
         key="di_motor_current_rear",
         streaming_key=Signal.DI_MOTOR_CURRENT_R,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
         suggested_display_precision=2,
     ),
     TeslemetrySensorEntityDescription(
         key="di_motor_current_rear_left",
         streaming_key=Signal.DI_MOTOR_CURRENT_REL,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
         suggested_display_precision=2,
     ),
     TeslemetrySensorEntityDescription(
         key="di_motor_current_rear_right",
         streaming_key=Signal.DI_MOTOR_CURRENT_RER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
+        suggested_display_precision=2,
     ),
     TeslemetrySensorEntityDescription(
         key="di_salve_torque_command",
@@ -669,6 +661,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         suggested_display_precision=1,
+        streaming_value_fn=lambda x: float(x),
         entity_registry_enabled_default=False,
     ),
     TeslemetrySensorEntityDescription(
@@ -732,7 +725,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
-        suggested_display_precision=1,
+        suggested_display_precision=0,
         streaming_value_fn=lambda x: float(x),
         entity_registry_enabled_default=False,
     ),
@@ -742,18 +735,28 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
-        suggested_display_precision=1,
+        suggested_display_precision=0,
         streaming_value_fn=lambda x: float(x),
         entity_registry_enabled_default=False,
     ),
     TeslemetrySensorEntityDescription(
         key="di_voltage_battery_rear_left",
         streaming_key=Signal.DI_V_BAT_REL,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        suggested_display_precision=0,
+        streaming_value_fn=lambda x: float(x),
         entity_registry_enabled_default=False,
     ),
     TeslemetrySensorEntityDescription(
         key="di_voltage_battery_rear_right",
         streaming_key=Signal.DI_V_BAT_RER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        suggested_display_precision=0,
+        streaming_value_fn=lambda x: float(x),
         entity_registry_enabled_default=False,
     ),
     TeslemetrySensorEntityDescription(
@@ -765,7 +768,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="energy_remaining",
         streaming_key=Signal.ENERGY_REMAINING,
         streaming_value_fn=lambda x: float(x),
-
         state_class=SensorStateClass.TOTAL,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
@@ -911,7 +913,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
     ),
     TeslemetrySensorEntityDescription(
         key="pack_voltage",
-        suggested_display_precision=1,
+        suggested_display_precision=2,
         streaming_key=Signal.PACK_VOLTAGE,
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -934,6 +936,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         key="rated_range",
         streaming_key=Signal.RATED_RANGE,
         device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfLength.MILES,
         suggested_display_precision=1,
         entity_registry_enabled_default=False,
@@ -1002,12 +1005,101 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         streaming_key=Signal.EFFICIENCY_PACKAGE,
         entity_registry_enabled_default=False,
     ),
+    TeslemetrySensorEntityDescription(
+        key="estimated_hours_to_charge_termination",
+        streaming_key=Signal.ESTIMATED_HOURS_TO_CHARGE_TERMINATION,
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.HOURS,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    TeslemetrySensorEntityDescription(
+        key="drive_state_expected_energy_percent_at_trip_arrival",
+        streaming_key=Signal.EXPECTED_ENERGY_PERCENT_AT_TRIP_ARRIVAL,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        suggested_display_precision=1,
+    ),
+    TeslemetrySensorEntityDescription(
+        key="homelink_device_count",
+        streaming_key=Signal.HOMELINK_DEVICE_COUNT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    TeslemetrySensorEntityDescription(
+        key="powershare_hours_left",
+        streaming_key=Signal.POWERSHARE_HOURS_LEFT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTime.HOURS,
+        device_class=SensorDeviceClass.DURATION,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=2,
+        entity_registry_enabled_default=False,
+    ),
+    TeslemetrySensorEntityDescription(
+        key="powershare_instantaneous_power_kw",
+        streaming_key=Signal.POWERSHARE_INSTANTANEOUS_POWER_KW,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        device_class=SensorDeviceClass.POWER,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=2,
+        entity_registry_enabled_default=False,
+    ),
+    TeslemetrySensorEntityDescription(
+        key="powershare_status",
+        streaming_key=Signal.POWERSHARE_STATUS,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        options=[
+            "Unknown",
+            "Inactive",
+            "Handshaking",
+            "Init",
+            "Enabled",
+            "EnabledReconnectingSoon",
+            "Stopped"
+        ],
+        streaming_value_fn=lambda x: str(x).replace("PowerShareState",""),
+        entity_registry_enabled_default=False,
+    ),
+    TeslemetrySensorEntityDescription(
+        key="powershare_stop_reason",
+        streaming_key=Signal.POWERSHARE_STOP_REASON,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        options=[
+            "Unknown",
+            "None",
+            "SOCTooLow",
+            "Retry",
+            "Fault",
+            "User",
+            "Reconnecting",
+            "Authentication"
+        ],
+        streaming_value_fn=lambda x: str(x).replace("PowershareStopReasonStatus",""),
+        entity_registry_enabled_default=False,
+    ),
+    TeslemetrySensorEntityDescription(
+        key="powershare_type",
+        streaming_key=Signal.POWERSHARE_TYPE,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        options=[
+            "Unknown",
+            "None",
+            "Load",
+            "Home"
+        ],
+        streaming_value_fn=lambda x: str(x).replace("PowershareTypeStatus",""),
+        entity_registry_enabled_default=False,
+    ),
 )
-
 @dataclass(frozen=True, kw_only=True)
 class TeslemetryTimeEntityDescription(SensorEntityDescription):
     """Describes Teslemetry Sensor entity."""
-
     polling: bool = False
     variance: int = 60
     streaming_key: Signal | None = None
@@ -1144,7 +1236,6 @@ ENERGY_LIVE_DESCRIPTIONS: tuple[TeslemetryEnergySensorEntityDescription, ...] = 
         ],
     ),
 )
-
 
 WALL_CONNECTOR_DESCRIPTIONS: tuple[
     TeslemetryEnergySensorEntityDescription, ...

--- a/custom_components/teslemetry/sensor.py
+++ b/custom_components/teslemetry/sensor.py
@@ -600,7 +600,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
-        suggested_display_precision=2,
+        suggested_display_precision=0,
     ),
     TeslemetrySensorEntityDescription(
         key="di_motor_current_rear",
@@ -609,7 +609,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
-        suggested_display_precision=2,
+        suggested_display_precision=0,
     ),
     TeslemetrySensorEntityDescription(
         key="di_motor_current_rear_left",
@@ -618,7 +618,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
-        suggested_display_precision=2,
+        suggested_display_precision=0,
     ),
     TeslemetrySensorEntityDescription(
         key="di_motor_current_rear_right",
@@ -627,7 +627,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
-        suggested_display_precision=2,
+        suggested_display_precision=0,
     ),
     TeslemetrySensorEntityDescription(
         key="di_salve_torque_command",

--- a/custom_components/teslemetry/translations/en.json
+++ b/custom_components/teslemetry/translations/en.json
@@ -431,7 +431,7 @@
         "name": "Scheduled departure time"
       },
       "charge_state_usable_battery_level": {
-        "name": "Battery Level Usable"
+        "name": "Battery Usable"
       },
       "climate_state_driver_temp_setting": {
         "name": "Driver temperature setting"

--- a/custom_components/teslemetry/translations/en.json
+++ b/custom_components/teslemetry/translations/en.json
@@ -211,7 +211,7 @@
     },
     "cover": {
       "charge_state_charge_port_door_open": {
-        "name": "Charge door"
+        "name": "Charge port"
       },
       "vehicle_state_ft": {
         "name": "Frunk"

--- a/custom_components/teslemetry/translations/en.json
+++ b/custom_components/teslemetry/translations/en.json
@@ -51,7 +51,7 @@
         "name": "Trip charging"
       },
       "climate_state_cabin_overheat_protection_actively_cooling": {
-        "name": "Cabin overheat protection actively cooling"
+        "name": "COP Running"
       },
       "climate_state_is_preconditioning": {
         "name": "Preconditioning"
@@ -123,16 +123,16 @@
         "name": "Rear passenger window"
       },
       "vehicle_state_tpms_soft_warning_fl": {
-        "name": "Tire pressure warning front left"
+        "name": "TPMS warning front left"
       },
       "vehicle_state_tpms_soft_warning_fr": {
-        "name": "Tire pressure warning front right"
+        "name": "TPMS warning front right"
       },
       "vehicle_state_tpms_soft_warning_rl": {
-        "name": "Tire pressure warning rear left"
+        "name": "TPMS warning rear left"
       },
       "vehicle_state_tpms_soft_warning_rr": {
-        "name": "Tire pressure warning rear right"
+        "name": "TPMS warning rear right"
       },
       "pin_to_drive_enabled": {
         "name": "Pin To Drive Enabled"
@@ -164,22 +164,22 @@
     },
     "button": {
       "boombox": {
-        "name": "Play fart"
+        "name": "Fart"
       },
       "enable_keyless_driving": {
-        "name": "Keyless driving"
+        "name": "Keyless"
       },
       "flash_lights": {
-        "name": "Flash lights"
+        "name": "Flash"
       },
       "homelink": {
         "name": "Homelink"
       },
       "honk": {
-        "name": "Honk horn"
+        "name": "Horn"
       },
       "refresh": {
-        "name": "Force refresh"
+        "name": "Refresh"
       },
       "wake": {
         "name": "Wake"
@@ -187,7 +187,7 @@
     },
     "climate": {
       "climate_state_cabin_overheat_protection": {
-        "name": "Cabin overheat protection"
+        "name": "COP"
       },
       "driver_temp": {
         "name": "Climate",
@@ -211,7 +211,7 @@
     },
     "cover": {
       "charge_state_charge_port_door_open": {
-        "name": "Charge port door"
+        "name": "Charge door"
       },
       "vehicle_state_ft": {
         "name": "Frunk"
@@ -220,7 +220,7 @@
         "name": "Trunk"
       },
       "windows": {
-        "name": "Vent windows"
+        "name": "Windows"
       },
       "vehicle_state_sun_roof_state": {
         "name": "Sun roof"
@@ -364,13 +364,13 @@
     },
     "sensor": {
       "battery_power": {
-        "name": "Battery power"
+        "name": "Battery Power"
       },
       "charge_state_battery_level": {
-        "name": "Battery level"
+        "name": "Battery Level"
       },
       "charge_state_battery_range": {
-        "name": "Battery range"
+        "name": "Battery Range"
       },
       "charge_state_charging_state": {
         "name": "Charging",
@@ -384,7 +384,7 @@
         }
       },
       "charge_state_charge_energy_added": {
-        "name": "Charge energy added"
+        "name": "Energy added"
       },
       "charge_state_charge_rate": {
         "name": "Charge rate"
@@ -402,13 +402,13 @@
         "name": "Charge cable"
       },
       "charge_state_est_battery_range": {
-        "name": "Estimate battery range"
+        "name": "Range Estimated"
       },
       "charge_state_fast_charger_type": {
         "name": "Fast charger type"
       },
       "charge_state_ideal_battery_range": {
-        "name": "Ideal battery range"
+        "name": "Range Ideal"
       },
       "charge_state_time_to_full_charge": {
         "name": "Time to full charge"
@@ -426,7 +426,7 @@
         "name": "Scheduled departure time"
       },
       "charge_state_usable_battery_level": {
-        "name": "Usable Battery level"
+        "name": "Battery Level Usable"
       },
       "climate_state_driver_temp_setting": {
         "name": "Driver temperature setting"
@@ -441,7 +441,7 @@
         "name": "Passenger temperature setting"
       },
       "drive_state_active_route_energy_at_arrival": {
-        "name": "State of charge at arrival"
+        "name": "SoC at arrival"
       },
       "drive_state_active_route_miles_to_arrival": {
         "name": "Distance to arrival"
@@ -459,7 +459,7 @@
         "name": "Power"
       },
       "drive_state_shift_state": {
-        "name": "Shift state",
+        "name": "Shift",
         "state": {
           "d": "Drive",
           "n": "Neutral",
@@ -517,10 +517,10 @@
         "name": "Brake Pedal Position"
       },
       "brick_voltage_max": {
-        "name": "Brick Voltage Max"
+        "name": "Battery Voltage Max"
       },
       "brick_voltage_min": {
-        "name": "Brick Voltage Min"
+        "name": "Battery Voltage Min"
       },
       "car_type": {
         "name": "Car Type"
@@ -637,7 +637,7 @@
         "name": "Emergency Lane Departure Avoidance"
       },
       "energy_remaining": {
-        "name": "Pack Remaining"
+        "name": "Battery Remaining"
       },
       "forward_collision_warning": {
         "name": "Forward Collision Warning"
@@ -673,10 +673,10 @@
         "name": "Longitudinal Acceleration"
       },
       "module_temp_max": {
-        "name": "Module Temperature Maximum"
+        "name": "Battery Temperature Max"
       },
       "module_temp_min": {
-        "name": "Module Temperature Minimum"
+        "name": "Battery Temperature Min"
       },
       "no_enough_power_to_heat": {
         "name": "Not Enough Power To Heat"
@@ -694,10 +694,10 @@
         "name": "Module Number Temperature Minimum"
       },
       "pack_current": {
-        "name": "Pack Current"
+        "name": "Battery Current"
       },
       "pack_voltage": {
-        "name": "Pack Voltage"
+        "name": "Battery Voltage"
       },
       "paired_key_quantity": {
         "name": "Number of paired Keys"
@@ -706,7 +706,7 @@
         "name": "Pedal Position"
       },
       "rated_range": {
-        "name": "Rated Range"
+        "name": "Range Rated"
       },
       "route_last_updated": {
         "name": "Route Last Updated"
@@ -715,7 +715,7 @@
         "name": "Sentry Mode"
       },
       "state_of_charge": {
-        "name": "State of charge"
+        "name": "Battery SoC"
       },
       "speed_limit_warning": {
         "name": "Speed Limit Warning"
@@ -742,28 +742,28 @@
         "name": "Odometer"
       },
       "vehicle_state_tpms_last_seen_pressure_time_fl": {
-        "name": "Tire pressure last measured front left"
+        "name": "TPMS last measured front left"
       },
       "vehicle_state_tpms_last_seen_pressure_time_fr": {
-        "name": "Tire pressure last measured front right"
+        "name": "TPMS last measured front right"
       },
       "vehicle_state_tpms_last_seen_pressure_time_rl": {
-        "name": "Tire pressure last measured rear left"
+        "name": "TPMS last measured rear left"
       },
       "vehicle_state_tpms_last_seen_pressure_time_rr": {
-        "name": "Tire pressure last measured rear right"
+        "name": "TPMS last measured rear right"
       },
       "vehicle_state_tpms_pressure_fl": {
-        "name": "Tire pressure front left"
+        "name": "TPMS front left"
       },
       "vehicle_state_tpms_pressure_fr": {
-        "name": "Tire pressure front right"
+        "name": "TPMS front right"
       },
       "vehicle_state_tpms_pressure_rl": {
-        "name": "Tire pressure rear left"
+        "name": "TPMS rear left"
       },
       "vehicle_state_tpms_pressure_rr": {
-        "name": "Tire pressure rear right"
+        "name": "TPMS rear right"
       },
       "version": {
         "name": "Version"
@@ -864,10 +864,34 @@
         "name": "Grid exported"
       },
       "center_display": {
-        "name": "Center Display"
+        "name": "Center display"
       },
       "efficiency_package": {
-        "name": "Efficiency Package"
+        "name": "Efficiency package"
+      },
+      "estimated_hours_to_charge_termination": {
+        "name": "Estimated hours to charge termination"
+      },
+      "drive_state_expected_energy_percent_at_trip_arrival": {
+        "name": "Expected energy percent at trip arrival"
+      },
+      "homelink_device_count": {
+        "name": "Homelink device count"
+      },
+      "powershare_hours_left": {
+        "name": "Powershare hours left"
+      },
+      "powershare_instantaneous_power_kw": {
+        "name": "Powershare instantaneous power"
+      },
+      "powershare_status": {
+        "name": "Powershare status"
+      },
+      "powershare_stop_reason": {
+        "name": "Powershare stop reason"
+      },
+      "powershare_type": {
+        "name": "Powershare type"
       }
     },
     "switch": {
@@ -893,10 +917,10 @@
         "name": "Storm watch"
       },
       "vehicle_state_sentry_mode": {
-        "name": "Sentry mode"
+        "name": "Sentry"
       },
       "vehicle_state_valet_mode": {
-        "name": "Valet mode"
+        "name": "Valet"
       }
     },
     "update": {

--- a/custom_components/teslemetry/translations/en.json
+++ b/custom_components/teslemetry/translations/en.json
@@ -51,7 +51,7 @@
         "name": "Trip charging"
       },
       "climate_state_cabin_overheat_protection_actively_cooling": {
-        "name": "COP Running"
+        "name": "Cabin overheat protection active"
       },
       "climate_state_is_preconditioning": {
         "name": "Preconditioning"
@@ -167,7 +167,7 @@
         "name": "Fart"
       },
       "enable_keyless_driving": {
-        "name": "Keyless"
+        "name": "Keyless driving"
       },
       "flash_lights": {
         "name": "Flash"
@@ -187,7 +187,7 @@
     },
     "climate": {
       "climate_state_cabin_overheat_protection": {
-        "name": "COP"
+        "name": "Cabin overheat protection"
       },
       "driver_temp": {
         "name": "Climate",
@@ -250,7 +250,7 @@
     },
     "media_player": {
       "media": {
-        "name": "Media Player"
+        "name": "Media player"
       }
     },
     "number": {
@@ -364,13 +364,13 @@
     },
     "sensor": {
       "battery_power": {
-        "name": "Battery Power"
+        "name": "Battery power"
       },
       "charge_state_battery_level": {
-        "name": "Battery Level"
+        "name": "Battery level"
       },
       "charge_state_battery_range": {
-        "name": "Battery Range"
+        "name": "Battery range"
       },
       "charge_state_charging_state": {
         "name": "Charging",
@@ -402,13 +402,13 @@
         "name": "Charge cable"
       },
       "charge_state_est_battery_range": {
-        "name": "Range Estimated"
+        "name": "Estimated range"
       },
       "charge_state_fast_charger_type": {
         "name": "Fast charger type"
       },
       "charge_state_ideal_battery_range": {
-        "name": "Range Ideal"
+        "name": "Ideal range"
       },
       "charge_state_time_to_full_charge": {
         "name": "Time to full charge"
@@ -431,7 +431,7 @@
         "name": "Scheduled departure time"
       },
       "charge_state_usable_battery_level": {
-        "name": "Battery Usable"
+        "name": "Usable battery"
       },
       "climate_state_driver_temp_setting": {
         "name": "Driver temperature setting"
@@ -522,10 +522,10 @@
         "name": "Brake Pedal Position"
       },
       "brick_voltage_max": {
-        "name": "Battery Voltage Max"
+        "name": "Battery max voltage"
       },
       "brick_voltage_min": {
-        "name": "Battery Voltage Min"
+        "name": "Battery min voltage"
       },
       "car_type": {
         "name": "Car Type"
@@ -642,7 +642,7 @@
         "name": "Emergency Lane Departure Avoidance"
       },
       "energy_remaining": {
-        "name": "Battery Remaining"
+        "name": "Battery remaining"
       },
       "forward_collision_warning": {
         "name": "Forward Collision Warning",
@@ -689,10 +689,10 @@
         "name": "Longitudinal Acceleration"
       },
       "module_temp_max": {
-        "name": "Battery Temperature Max"
+        "name": "Battery max temperature"
       },
       "module_temp_min": {
-        "name": "Battery Temperature Min"
+        "name": "Battery min temperature"
       },
       "no_enough_power_to_heat": {
         "name": "Not Enough Power To Heat"
@@ -710,10 +710,10 @@
         "name": "Module Number Temperature Minimum"
       },
       "pack_current": {
-        "name": "Battery Current"
+        "name": "Battery current"
       },
       "pack_voltage": {
-        "name": "Battery Voltage"
+        "name": "Battery voltage"
       },
       "paired_key_quantity": {
         "name": "Number of paired Keys"
@@ -722,7 +722,7 @@
         "name": "Pedal Position"
       },
       "rated_range": {
-        "name": "Range Rated"
+        "name": "Rated range"
       },
       "route_last_updated": {
         "name": "Route Last Updated"


### PR DESCRIPTION
Hello,

Second pull request, here. Doing it now because of the 3.x alphas.

I'm not too sure if it's better to create smaller PRs with every block of modifications, rather than this single PR with all the modifications. If needed, I can do smaller ones.

Hope the changes proposed are in line of the project and provide useful UI changes.

Thanks!

## **Changelog:**

### 🎨 **Icons**
- **Updated** for new naming of signals (previous stream)
- **Added**:
  - Preconditioning
  - Dashcam
  - Door locks
  - Charge cable
  - Scheduled charging
  - Emergency lane departure
  - Fast charger type
  - Center display
  - Traffic delay
  - Speed limit warning
  - Exterior color
- **Updated**:
  - Boombox
  - Flash headlights
  - Charging state disconnected

### 📊 **Sensors**
- Set display precision according to the reported decimals by the API
- Removed TPMS suggested PSI. Home Assistant transforms to the user region settings
- Linting of white lines between sensors
- **Added details**:
  - *Drive Inverter Heatsink*: type, precision (reports 1 decimal 0.5º steps)
  - *Drive Inverter Current*: type, precision (reports 0 decimals)
  - *Speed*: precision (reports 0 decimals)
  - *TPMS*: precision (reports 3 decimals, usable for UI in BAR mode)
  - *Battery Voltages*: precision (reports 3 decimals, useful for cell imbalance calculations in mV)
  - *AC / DC Charging*: precision (reports 2 decimals)
  - *DI Stator Front*: lambda function
  - *Drive Inverter Battery Input*: precision (reports 0 decimals, added for rear right and rear left units)
  - *Pack Voltage*: precision (reports 2 decimals)
  - *Rated Range*: state class measurement (as other range sensors)

### 🌐 **Translations**
- **Updated** for new naming of signals (previous stream)
- Unified pack, module, and brick to *Battery X* (name of sensor)
- Naming position reordered to have all same types of signals close-by (ex. ranges, battery, ...)
- Naming capitalization to unify
- **Added sensor abbreviations** (as in the API and docs):
  - Cabin Overheat Protection to *COP*
  - Tire pressure monitoring to *TPMS*
  - State of charge to *SoC*
- **Updated**:
  - Fart (simplified from play fart)
  - Sentry (simplified from sentry mode)
  - Keyless (simplified from keyless driving)
  - Refresh (simplified from force refresh)
  - Windows (simplified from vent windows)
  - Shift (simplified from shift state)
  - Valet (simplified from valet mode)
  - Charge port (not used anywhere - from charge door)