### PR TITLE
Add RRULE support for recurring events in calendar

### DIFF
--- a/custom_components/teslemetry/calendar.py
+++ b/custom_components/teslemetry/calendar.py
@@ -82,7 +82,10 @@ def get_rrule_days(days_of_week: int) -> list[str]:
 
 def parse_rrule(rrule: str) -> dict[str,str]:
     """Parse an rrule string into a dictionary of configurations."""
-    return dict(s.split("=") for s in rrule.split(";"))
+    rrule_dict = dict(s.split("=") for s in rrule.split(";"))
+    if "BYDAY" in rrule_dict:
+        rrule_dict["BYDAY"] = rrule_dict["BYDAY"].split(",")
+    return rrule_dict
 
 def test_days_of_week(date: datetime, test_days_of_week: int) -> bool:
     """Check if a specific day is in the days_of_week binary."""


### PR DESCRIPTION
Update the `parse_rrule` function to handle RRULE strings for recurring events.

* Modify the `parse_rrule` function to split the "BYDAY" value into a list of days if it exists

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Teslemetry/hass-teslemetry/pull/210?shareId=237c1ed5-2ebf-4a35-9428-94e1902a97e0).