### PR TITLE
Ensure wall connector devices are not removed on reload.

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -178,6 +178,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
             )
             current_devices.add((DOMAIN, str(site_id)))
 
+            # Add wall connector devices to our device list ensuring they are not considered no longer present.
+            if wall_connector:
+                for connector in product["components"]["wall_connectors"]:
+                    current_devices.add((DOMAIN, connector.get("din", "")))            
+            
             # Check live status endpoint works before creating its coordinator
             try:
                 live_status = (await api.live_status())["response"]


### PR DESCRIPTION
Fix for #227 ensuring that wall connector devices are not being removed on restart or reload of Teslemetry.
Removal of devices was added through PR [#144523](https://github.com/home-assistant/core/pull/144523)
