### PR TITLE
docs: switch release process from rebase+force-push to merge-based dev tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,3 +136,10 @@ When resolving merge conflicts:
 - A PR re-introducing old code that a previously-applied PR already changed (e.g. reverting translated exceptions back to plain strings)
 - Two PRs both creating the same new file (e.g. calendar.py) — combine both into one file with a shared `async_setup_entry`
 - Nested conflict markers (`<<<<<<< ours` inside another `<<<<<<< ours`) from three-way merge fallback — always grep after committing
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,20 +14,34 @@ gh release ls --repo teslemetry/hass-teslemetry --limit 1
 
 Parse the current version (e.g. `v0.5.2`) and bump the appropriate segment. Strip the `v` prefix for the version string used in manifest/commits (e.g. `0.6.0`).
 
-### 2. Rebase onto upstream
+### Working model: isolated worktree, never check out main
+
+This process runs in an isolated worktree, not the primary checkout. **Never run `git checkout main` anywhere in this process** - `main` is typically checked out in a shared primary clone, and checking it out here dirties that shared clone. Every step that touches `main` goes through a temporary branch, delivered with a plain non-force `git push origin <temp-branch>:main`. Nothing in this process rebases `main` or force-pushes.
+
+### 2. Sync main with upstream dev
+
+`main` tracks home-assistant/core `dev`. This sync is automatic as part of every release build - there is no separate approval PR for it.
 
 ```bash
-git checkout main
+git fetch origin main
 git fetch upstream dev
-git rebase upstream/dev
-git push --force-with-lease
+git checkout -b sync-dev origin/main
+git merge upstream/dev   # append-only; resolve conflicts by editing files directly, same as step 4
+git push origin sync-dev:main
 ```
+
+- Resolve any merge conflicts the same way as PR conflicts in step 4: read the conflicting files and edit directly, no `git mergetool`.
+- The push is a plain non-force push (no `--force` / `--force-with-lease`). If it's rejected as non-fast-forward, someone else pushed to `main` in the meantime - re-fetch `origin/main`, re-merge `upstream/dev` into `sync-dev`, and push again. Never force the push.
+
+You stay on `sync-dev` (now holding the synced state of `main`) for the next step.
 
 ### 3. Create release branch
 
 ```bash
 git checkout -b release-$VERSION
 ```
+
+Branches off the `sync-dev` state from step 2, so no further checkout is needed. If starting fresh instead (e.g. resuming in a new worktree), use `git fetch origin main && git checkout -b release-$VERSION origin/main` - never `git checkout main` first.
 
 ### 4. Apply PR patches
 
@@ -105,8 +119,6 @@ gh release create v$VERSION -F release_notes.txt --repo Teslemetry/hass-teslemet
 gh release upload v$VERSION teslemetry.zip --repo Teslemetry/hass-teslemetry
 rm teslemetry.zip
 git push --set-upstream origin release-$VERSION
-git checkout main
-git restore .
 ```
 
 ## Conflict resolution guidelines


### PR DESCRIPTION
## Intent
- Stop force-pushing `main` during the dev sync step
  - The old step 2 did `git checkout main; git rebase upstream/dev; git push --force-with-lease`
  - Force-pushing rewrites history on every release, which invalidates any downstream clone of this repo and fights fleet safety tooling that correctly refuses to force or discard changes
  - Fix: replace the rebase with an append-only merge. `git merge upstream/dev` on a temp branch (`sync-dev`) cut from `origin/main`, delivered with a plain non-force `git push origin sync-dev:main`. Same conflict surface as before, but the resolutions are ordinary merge commits that persist across releases instead of being replayed and force-pushed away
  - The dev sync stays fully automatic inside the release build, same as before - there's no new approval PR gate for it
  - Added a concurrent-push recovery path: if the non-force push is rejected as non-fast-forward, re-fetch `origin/main`, re-merge `upstream/dev`, and retry - never force
- Make the process safe to run from an isolated crew worktree
  - The release build runs as a crew in an isolated worktree off a pooled clone whose `main` is checked out in a separate primary clone. A `git checkout main` in the worktree operates on and dirties that shared primary clone - this actually happened
  - Fix: added an explicit "Working model" note ahead of step 2 stating the hard rule - never `git checkout main` anywhere in this process. Every step that touches `main` now goes through a temp branch (`sync-dev` in step 2, or a fresh `origin/main` fetch in step 3) instead of checking it out directly
  - Removed the trailing `git checkout main` / `git restore .` cleanup at the end of step 8 - the crew worktree is disposable and torn down by firstmate, so there's nothing to "return to"
- Scope: docs-only change to `AGENTS.md` (`CLAUDE.md` is a symlink to it, so it updates too). Nothing under `homeassistant/components/teslemetry/` or `tests/` touched. All other steps - version bump, PR patch apply (step 4), version/build (step 5), tests (step 6), the approval pause (step 7), and the tag/zip/publish commands (step 8) - are unchanged.

<details>
<summary>Full narrative / original brief</summary>

This repo's `main` tracks home-assistant/core `dev`. The previous release process did a rebase-and-force-push sync onto `main` from a checked-out `main` branch. Two problems surfaced:

1. Force-pushing `main` rewrites history on every release, invalidating every downstream clone and conflicting with fleet safety tooling that intentionally refuses to force-push or discard work.
2. The release build now runs as an isolated crew worktree off a pooled clone whose `main` is checked out in the shared primary. Checking out `main` inside that worktree dirties the shared clone - this happened in practice.

The fix switches the dev sync to an append-only merge on a temp branch (`sync-dev`), delivered with a non-force `git push origin sync-dev:main`, with a re-fetch-and-retry recovery for concurrent pushes. The whole process was also audited to remove every `git checkout main`, replacing each with a temp-branch or fresh-fetch pattern, and the trailing return-to-main cleanup at the end of publish was dropped since the worktree is disposable.

</details>
