### PR TITLE
docs: add standing built-in Tessie/Tesla Fleet compatibility note to release notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,15 @@ grep -r "<<<<<<" homeassistant/components/teslemetry/ tests/components/teslemetr
 
 If markers are found, fix them immediately and amend the commit before proceeding to the next PR.
 
-Write each applied PR to `release_notes.txt` as: `[#$PR_NUMBER](https://github.com/home-assistant/core/pull/$PR_NUMBER): $PR_TITLE`
+Start `release_notes.txt` with the standing compatibility note below, verbatim, before any per-PR lines:
+
+```
+> ⚠️ **Compatibility with the built-in Tessie and Tesla Fleet integrations**
+>
+> This beta pins a newer `tesla-fleet-api` than the latest released Home Assistant Core version ships. The built-in **Tessie** and **Tesla Fleet** integrations share that library, so this beta is incompatible with them whenever its pinned `tesla-fleet-api` is ahead of the version in the latest core release — which is almost always. Do not run this beta alongside the built-in Tessie or Tesla Fleet integrations.
+```
+
+Then write each applied PR to `release_notes.txt` as: `[#$PR_NUMBER](https://github.com/home-assistant/core/pull/$PR_NUMBER): $PR_TITLE`
 
 ### 5. Update version and build
 


### PR DESCRIPTION
## What

Adds a step to the release-notes generation (step 4) that starts every `release_notes.txt` with a standing compatibility warning, verbatim, before the per-PR lines. AGENTS.md-only; no component code change.

## Why

This beta always pins a newer `tesla-fleet-api` than the latest released Home Assistant Core ships. The built-in **Tessie** and **Tesla Fleet** integrations share that library, so running this beta alongside either of them is broken whenever the pinned version is ahead of core's - which is effectively every release. Baking the note into the release-notes step means every future cut carries it automatically instead of relying on someone remembering to add it by hand.

Applied retroactively to the currently published v6.0.7 and v6.0.8 release notes as a separate, non-code action (release notes only, no re-tag/re-publish).
