### PR TITLE
Fix ClickStack log shipping silently dying after a config-entry reload

### DIFF
--- a/homeassistant/components/teslemetry/logship.py
+++ b/homeassistant/components/teslemetry/logship.py
@@ -40,6 +40,10 @@ SHIPPED_LOGGERS = (
 _GATE_LOGGER_NAME = "homeassistant.components.teslemetry"
 _INTERNAL_LOGGER_NAME = __name__
 
+# This module's own diagnostics logger. _OTLPLogHandler.emit excludes it by
+# name, so its warnings never get shipped or feed back into the buffer.
+_LOGGER = logging.getLogger(_INTERNAL_LOGGER_NAME)
+
 MAX_BUFFER_SIZE = 1000
 BATCH_SIZE = 200
 FLUSH_INTERVAL = 5.0
@@ -142,22 +146,34 @@ class TeslemetryLogShipper:
         self.hass = hass
         self.uid = uid
         self._refcount = 0
+        self._attached = False
         self._buffer: deque[logging.LogRecord] = deque(maxlen=MAX_BUFFER_SIZE)
         self._handler = _OTLPLogHandler(self._buffer)
         self._resource_attrs: dict[str, Any] = {}
         self._task: asyncio.Task | None = None
 
     async def async_acquire(self) -> None:
-        """Attach handlers and start the export loop on first use."""
+        """Attach handlers and start the export loop on first use.
+
+        Refcount only increments once attach succeeds, so a failed attach
+        stays retryable on the next acquire instead of poisoning the singleton.
+        """
+        if not self._attached:
+            try:
+                self._resource_attrs = await self._async_build_resource_attrs()
+            except Exception:
+                _LOGGER.warning(
+                    "ClickStack log shipping failed to start, will retry on next setup"
+                )
+                raise
+            for name in SHIPPED_LOGGERS:
+                logging.getLogger(name).addHandler(self._handler)
+            self._task = self.hass.async_create_background_task(
+                self._async_export_loop(), "teslemetry_logship"
+            )
+            self._task.add_done_callback(self._on_export_task_done)
+            self._attached = True
         self._refcount += 1
-        if self._refcount > 1:
-            return
-        self._resource_attrs = await self._async_build_resource_attrs()
-        for name in SHIPPED_LOGGERS:
-            logging.getLogger(name).addHandler(self._handler)
-        self._task = self.hass.async_create_background_task(
-            self._async_export_loop(), "teslemetry_logship"
-        )
 
     def async_release(self) -> None:
         """Detach handlers and stop the export loop once unused."""
@@ -169,7 +185,14 @@ class TeslemetryLogShipper:
         if self._task is not None:
             self._task.cancel()
             self._task = None
+        self._attached = False
         _shippers.pop(self.hass, None)
+
+    def _on_export_task_done(self, task: asyncio.Task) -> None:
+        """Warn if the export loop stopped without being released."""
+        if task.cancelled() or (exc := task.exception()) is None:
+            return
+        _LOGGER.warning("ClickStack log shipping stopped unexpectedly: %s", exc)
 
     async def _async_build_resource_attrs(self) -> dict[str, Any]:
         """Collect resource attributes shipped with every batch."""

--- a/tests/components/teslemetry/test_logship.py
+++ b/tests/components/teslemetry/test_logship.py
@@ -2,6 +2,7 @@
 
 from collections.abc import AsyncGenerator
 import logging
+from unittest.mock import patch
 
 from aiohttp import ClientConnectionError
 import pytest
@@ -18,7 +19,7 @@ from homeassistant.components.teslemetry.logship import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
-from . import mock_config_entry
+from . import mock_config_entry, reload_platform, setup_platform
 from .const import UNIQUE_ID
 
 from tests.common import MockConfigEntry
@@ -242,6 +243,116 @@ async def test_attach_detach_refcounting(hass: HomeAssistant) -> None:
     log_shipper.async_release()
     assert log_shipper._handler not in logging.getLogger(LIBRARY_LOGGER).handlers
     assert log_shipper._task is None
+
+
+async def test_reload_reattaches_handler_and_export_task(
+    hass: HomeAssistant,
+) -> None:
+    """A config-entry reload must re-attach the handler and restart export."""
+    entry = await setup_platform(hass)
+
+    first_shipper = get_logship(hass)
+    assert first_shipper is not None
+    assert first_shipper._handler in logging.getLogger(LIBRARY_LOGGER).handlers
+    assert first_shipper._task is not None
+    assert not first_shipper._task.done()
+
+    await reload_platform(hass, entry)
+
+    second_shipper = get_logship(hass)
+    assert second_shipper is not None
+    assert second_shipper._handler in logging.getLogger(LIBRARY_LOGGER).handlers
+    assert second_shipper._task is not None
+    assert not second_shipper._task.done()
+
+
+async def test_acquire_failure_warns_and_does_not_poison_refcount(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failed attach warns visibly and leaves the shipper retryable."""
+    log_shipper = TeslemetryLogShipper(hass, UNIQUE_ID)
+    caplog.set_level(logging.WARNING, logger=f"{COMPONENT_LOGGER}.logship")
+
+    with (
+        patch.object(
+            log_shipper,
+            "_async_build_resource_attrs",
+            side_effect=RuntimeError("transient failure"),
+        ),
+        pytest.raises(RuntimeError),
+    ):
+        await log_shipper.async_acquire()
+
+    assert "ClickStack log shipping failed to start" in caplog.text
+    assert log_shipper._refcount == 0
+    assert not log_shipper._attached
+    assert log_shipper._handler not in logging.getLogger(LIBRARY_LOGGER).handlers
+
+    await log_shipper.async_acquire()
+    try:
+        assert log_shipper._handler in logging.getLogger(LIBRARY_LOGGER).handlers
+        assert log_shipper._task is not None
+    finally:
+        log_shipper.async_release()
+
+
+async def test_export_task_death_warns(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An export loop that dies unexpectedly warns instead of going silent."""
+    log_shipper = TeslemetryLogShipper(hass, UNIQUE_ID)
+    caplog.set_level(logging.WARNING, logger=f"{COMPONENT_LOGGER}.logship")
+
+    with (
+        pytest.MonkeyPatch.context() as monkeypatch,
+        patch.object(log_shipper, "_async_flush", side_effect=RuntimeError("loop bug")),
+    ):
+        monkeypatch.setattr(
+            "homeassistant.components.teslemetry.logship.FLUSH_INTERVAL", 0
+        )
+        await log_shipper.async_acquire()
+        try:
+            with pytest.raises(RuntimeError):
+                await log_shipper._task
+        finally:
+            log_shipper._task = None
+            log_shipper.async_release()
+
+    assert "ClickStack log shipping stopped unexpectedly" in caplog.text
+
+
+async def test_transient_acquire_failure_then_reload_reattaches(
+    hass: HomeAssistant,
+) -> None:
+    """A one-time acquire failure must not permanently poison the shipper."""
+    original = TeslemetryLogShipper._async_build_resource_attrs
+    call_count = 0
+
+    async def flaky(self):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("transient failure")
+        return await original(self)
+
+    with patch.object(TeslemetryLogShipper, "_async_build_resource_attrs", flaky):
+        entry = mock_config_entry()
+        entry.add_to_hass(hass)
+        first_result = await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        reload_result = await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert first_result is False
+    assert reload_result is True
+    shipper = get_logship(hass)
+    assert shipper is not None
+    assert shipper._handler in logging.getLogger(LIBRARY_LOGGER).handlers
+    assert shipper._task is not None
+    assert not shipper._task.done()
 
 
 async def test_setup_entry_shares_singleton_across_entries(


### PR DESCRIPTION
## Intent

- **Bug**: ClickStack log shipping silently stops after a config-entry reload and never resumes, with no error or warning anywhere.
- **Root cause**: `TeslemetryLogShipper.async_acquire()` incremented `_refcount` *before* awaiting `_async_build_resource_attrs()`. If that await ever raises (e.g. a transient failure looking up the integration/instance id), the refcount is left elevated but the handler was never attached and the export task never started. Because `entry.async_on_unload(logship.async_release)` is only registered *after* `async_acquire()` returns successfully, the release callback never gets registered either - the poisoned singleton is never cleaned up. Every subsequent setup attempt (including a plain reload) then finds `_refcount > 1` on the existing singleton and returns immediately without retrying the attach. Permanent, silent, and only clearable by a full process restart (which resets the module-level `_shippers` singleton table).
- **Fix**: track attach state independently of refcount (`_attached: bool`). Refcount only increments once the handler has actually attached and the export task has actually started; a failed attach leaves `_attached` false so the *next* acquire (retry or reload) retries the attach instead of short-circuiting on a stale count.
- **Also closes the silence**: a failed attach and an export task that dies unexpectedly now both log a `WARNING` via the module's own logger (excluded from shipping by the existing self-log guard, unaffected by the DEBUG gate since that only gates `_OTLPLogHandler.emit`). Previously both failure modes were completely invisible.

## Reproduction

Added a failing-first regression test that models the real trigger: a transient exception during the first `async_acquire()` (simulating a real-world transient failure, e.g. a slow/cold-boot integration lookup), followed by a normal `hass.config_entries.async_reload()` - the same sequence a user hits when Home Assistant reports a one-off setup error and they reload the entry. Before this fix, the reload reports success and the entry loads fine, but the log handler is never reattached. Also added a plain reload lifecycle test (`async_setup_entry -> async_unload_entry -> async_setup_entry`) as a baseline, since a *clean* reload with no intervening failure already worked correctly - the bug only reproduces once one acquire attempt has failed.

## What changed

- `homeassistant/components/teslemetry/logship.py` - `_attached` flag replaces the refcount-only attach gate in `async_acquire`/`async_release`; `WARNING` logging for a failed attach and for an export task that dies unexpectedly.
- `tests/components/teslemetry/test_logship.py` - regression tests for the reload/reattach path, the refcount-poisoning mechanism, and both new warning paths.

## Testing

- `uv run pytest tests/components/teslemetry/test_logship.py` -> 16 passed.
- `uv run pylint homeassistant/components/teslemetry/logship.py` -> clean.
- `uv run prek run --files homeassistant/components/teslemetry/logship.py tests/components/teslemetry/test_logship.py` -> clean.

## Not covered

A full HA *restart* (new process) resets the module-level `_shippers` table, so it isn't subject to this refcount-poisoning mechanism - a restart is actually self-healing here. Restart does interact with the DEBUG opt-in gate itself (whether a runtime "enable debug logging" choice survives a restart depends on the persistence option the user picked in the Settings UI), which is a separate, pre-existing product question about the gating model rather than a code defect - flagged separately for a decision, not addressed in this PR.
