### PR TITLE
Replace prose release runbook with a reproducible release.sh pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,162 +4,38 @@ This repository is the **HACS beta release** of the Teslemetry integration for H
 
 ## Task: build a release
 
-The user will say **major**, **minor**, or **patch**. Follow these steps:
-
-### 1. Determine version
+The whole release runs through one committed helper, **`release.sh`** (repo root). The user says **major**, **minor**, or **patch**; you invoke:
 
 ```bash
-gh release ls --repo teslemetry/hass-teslemetry --limit 1
+./release.sh <major|minor|patch>            # default: dry run, stops before the real publish
+./release.sh <major|minor|patch> --publish  # arms the real tag + GitHub release
 ```
 
-Parse the current version (e.g. `v0.5.2`) and bump the appropriate segment. Strip the `v` prefix for the version string used in manifest/commits (e.g. `0.6.0`).
+`release.sh` owns the deterministic HOW and mechanically enforces the gates this file used to trust an operator to remember. This section owns the WHY and the gotchas; the "HACS-only patches that ride `main`", "CI: the clean per-integration gate", and "Conflict resolution guidelines" sections below stay authoritative for the details the script's comments point back to. Do not re-add hand-run step lists here - they drift from the script.
 
-### Working model: isolated worktree, never check out main
+### Where the helper lives and why there
 
-This process runs in an isolated worktree, not the primary checkout. **Never run `git checkout main` anywhere in this process** - `main` is typically checked out in a shared primary clone, and checking it out here dirties that shared clone. Every step that touches `main` goes through a temporary branch, delivered with a plain non-force `git push origin <temp-branch>:main`. Nothing in this process rebases `main` or force-pushes.
+`release.sh` is a **fork-only tracked file at the repo root**, exactly like `.github/workflows/teslemetry-test.yml` and `release.yml`. Core `dev` has no `release.sh`, so the automatic core-`dev` sync never conflicts with or clobbers it, and the CI-strip only deletes paths under `.github/workflows/` - so the helper survives every cut untouched. Keep it there; do not move it under `script/` (that tree is core-synced and a name could collide upstream).
 
-### 2. Sync main with upstream dev
+### What the pipeline does, and where it stops for you
 
-`main` tracks home-assistant/core `dev`. This sync is automatic as part of every release build - there is no separate approval PR for it.
+It runs the phases the runbook used to spell out - version bump off the latest release; the `sync-dev` merge of `upstream/dev` + CI-strip + **non-force** `git push origin sync-dev:main` (with concurrent-push re-merge/retry); cutting `release-$VERSION`; applying Bre77's open core PRs oldest-to-newest; stamping both manifests; writing `release_notes.txt` (standing compat note prepended verbatim); the full local build gate; then the approval pause and publish. It **never** runs `git checkout main`, rebases, or force-pushes, so it is safe from an isolated worktree.
 
-```bash
-git fetch origin main
-git fetch upstream dev
-git checkout -b sync-dev origin/main
-git merge upstream/dev   # append-only; resolve conflicts by editing files directly, same as step 4
-```
+It pauses and hands control to you at exactly these points; everything else is automatic and fail-stop:
 
-- Resolve any merge conflicts the same way as PR conflicts in step 4: read the conflicting files and edit directly, no `git mergetool`.
-- **Strip core CI/CD workflow noise (every cut, durable).** Core `dev` carries its own `.github/workflows/`, and this merge is exactly what would otherwise resurrect the files this fork deliberately excludes (see "CI: the clean per-integration gate" below). Run this unconditionally right after the merge, whether it landed clean or a conflict hit one of these exact paths (upstream modifying a file this fork deleted shows as a `deleted by us` conflict - `git rm` also resolves that):
+- **Any conflict** - an `upstream/dev` merge conflict, a PR patch that doesn't apply cleanly, or the concurrent-push re-merge. The script prints what to read and resolve, you edit files directly (no `git mergetool`) and `git add` each resolved file **without committing**; the script finishes the commit and re-runs the conflict-marker grep. See "Conflict resolution guidelines" below.
+- **The TEMPORARY `quality_scale.yaml` checkpoint** - the script excludes `quality_scale.yaml` from every per-PR patch (it conflicts repeatedly while quality-scale work is in flight), then pauses once for you to write the correct combined final state from the PRs and `git add` it. Retire this checkpoint (and the exclusion in the script) once the quality scale PRs have all merged.
+- **The approval pause** - reached only after the build gate passed in full. The script shows the applied PRs, any conflicts resolved, and the green gate, then waits for you to type `publish`. Anything else aborts with nothing published.
 
-  ```bash
-  git rm -rf --ignore-unmatch \
-    .github/workflows/ci.yaml \
-    .github/workflows/validate.yml \
-    .github/workflows/check-requirements-deterministic.yml \
-    .github/workflows/check-requirements.lock.yml \
-    .github/workflows/check-requirements.md \
-    .github/workflows/codeql.yml \
-    .github/workflows/translations.yml \
-    .github/workflows/builder.yml \
-    .github/workflows/wheels.yml \
-    .github/workflows/e2e-tests.yml \
-    .github/workflows/matchers
-  git diff --cached --quiet || git commit -m "Strip core CI/CD workflow noise" --no-verify
-  ```
+### What the gates guarantee (all fail-stop, enforced by the script)
 
-  `--ignore-unmatch` makes it safe even when upstream didn't touch any of these paths this cycle (nothing staged, nothing committed). If the merge stopped on conflicts in unrelated files too, resolve those first, then run the strip, then commit once. Keep this path list in sync with the "CI: the clean per-integration gate" list below - it's the same set.
-- Then push:
+- **Conflict-marker grep after every commit** over the integration + tests - a leaked `<<<<<<<`/`>>>>>>>` stops the release.
+- **`device_tracker.py` stable-core compat grep** - asserts `ATTR_LATITUDE`/`ATTR_LONGITUDE` are present and the 2026.8-dev-only `EntityStateAttribute.LATITUDE`/`.LONGITUDE` are absent **from code** (a comment mention is allowed). This is the check v6.0.9 skipped; the build gate can't catch it (the break is stable-core-only). See "HACS-only patches that ride `main`" for the full why.
+- **Full build gate**, mirroring `.github/workflows/teslemetry-test.yml` command-for-command (`translations develop --all`, `hassfest --skip-plugins manifest`, `ruff check`/`format --check`, `pytest`) - any failure stops the release before the approval pause is ever reached. This is the real publish gate for this repo; there is no branch-protection required-check (the captain gates at publish).
 
-  ```bash
-  git push origin sync-dev:main
-  ```
+### Publish safety
 
-  The push is a plain non-force push (no `--force` / `--force-with-lease`). If it's rejected as non-fast-forward, someone else pushed to `main` in the meantime - re-fetch `origin/main`, re-merge `upstream/dev` into `sync-dev`, redo the strip, and push again. Never force the push.
-
-You stay on `sync-dev` (now holding the synced state of `main`) for the next step.
-
-### 3. Create release branch
-
-```bash
-git checkout -b release-$VERSION
-```
-
-Branches off the `sync-dev` state from step 2, so no further checkout is needed. If starting fresh instead (e.g. resuming in a new worktree), use `git fetch origin main && git checkout -b release-$VERSION origin/main` - never `git checkout main` first.
-
-### 4. Apply PR patches
-
-Get the list of open PRs:
-
-```bash
-gh pr list --repo home-assistant/core --author Bre77 --state open --label "integration: teslemetry" --json number,title
-```
-
-**Ordering**: Apply PRs from oldest to newest. If multiple PRs touch the same files (check with `gh pr diff --name-only`), apply them adjacently to minimize conflicts.
-
-**TEMPORARY**: While quality scale work is in progress, exclude `quality_scale.yaml` from each patch to avoid repeated conflicts. Apply it once at the end of step 4 by reading the final state of all PRs and writing the correct combined result. Remove this workaround once quality scale PRs are all merged.
-
-For each PR, apply its patch:
-
-```bash
-gh pr diff $PR_NUMBER --patch --repo home-assistant/core | git apply -3
-```
-
-- **If it applies cleanly**: stage and commit with `git commit -am "#$PR_NUMBER: $PR_TITLE" --no-verify`
-- **If it conflicts**: resolve by editing files directly (no `git mergetool`):
-  1. Run `git status` to find unmerged files
-  2. Read each conflicted file and the original PR (`gh pr diff $PR_NUMBER --repo home-assistant/core`) to understand intent
-  3. Edit to resolve conflicts, preserving both upstream and PR changes
-  4. `git add` resolved files, then `git commit -am "#$PR_NUMBER: $PR_TITLE" --no-verify`
-
-**After every commit**, verify no conflict markers leaked through:
-
-```bash
-grep -r "<<<<<<" homeassistant/components/teslemetry/ tests/components/teslemetry/ && echo "CONFLICT MARKERS FOUND - fix before continuing" || echo "Clean"
-```
-
-If markers are found, fix them immediately and amend the commit before proceeding to the next PR.
-
-Start `release_notes.txt` with the standing compatibility note below, verbatim, before any per-PR lines:
-
-```
-> ⚠️ **Compatibility with the built-in Tessie and Tesla Fleet integrations**
->
-> This beta pins a newer `tesla-fleet-api` than the latest released Home Assistant Core version ships. The built-in **Tessie** and **Tesla Fleet** integrations share that library, so this beta is incompatible with them whenever its pinned `tesla-fleet-api` is ahead of the version in the latest core release — which is almost always. Do not run this beta alongside the built-in Tessie or Tesla Fleet integrations.
-```
-
-Then write each applied PR to `release_notes.txt` as: `[#$PR_NUMBER](https://github.com/home-assistant/core/pull/$PR_NUMBER): $PR_TITLE`
-
-### 5. Update version and build
-
-```bash
-yq -i -o json ".version=\"$VERSION\"" "homeassistant/components/teslemetry/manifest.json"
-cp "homeassistant/components/teslemetry/manifest.json" "custom_components/teslemetry/manifest.json"
-```
-
-Append to `release_notes.txt`:
-```
-**Full Changelog**: https://github.com/Teslemetry/hass-teslemetry/commits/v$VERSION
-```
-
-Commit: `git commit -am "v$VERSION" --no-verify`
-
-### 6. Run the release gate - blocking, stop on any failure
-
-This is the actual publish gate for this repo (there is no branch-protection required-check - the captain gates at publish, not via a GitHub repo setting). If any command below fails, STOP: do not proceed to step 7 or step 8, and report the failure to the user instead of publishing.
-
-```bash
-source .venv/bin/activate
-script/setup
-uv pip install -r requirements_all.txt -r requirements_test.txt -r requirements_test_pre_commit.txt
-python3 -m script.translations develop --all
-python3 -m script.hassfest --integration-path homeassistant/components/teslemetry --skip-plugins manifest
-ruff check homeassistant/components/teslemetry tests/components/teslemetry
-ruff format --check homeassistant/components/teslemetry tests/components/teslemetry
-pytest tests/components/teslemetry
-deactivate
-```
-
-This mirrors `.github/workflows/teslemetry-test.yml` command-for-command (same `--skip-plugins manifest` reasoning - see "CI: the clean per-integration gate" below), so a release cut here can't diverge from what that workflow already checks on the PR. `teslemetry-test.yml` itself stays PR-visibility only; this step is what actually blocks a bad release from shipping.
-
-### 7. Pause for approval
-
-Only reached if step 6 passed in full. Show the user:
-- List of applied PRs and any conflicts that were resolved
-- Step 6's results (pytest/hassfest/ruff all green)
-- Ask for confirmation before publishing
-
-### 8. Publish release
-
-```bash
-git tag -a v$VERSION -m "Release $VERSION"
-git push origin v$VERSION
-cd homeassistant/components/teslemetry && rm -rf __pycache__ && rm -f *.orig && zip -r ../../../teslemetry.zip * && cd ../../..
-gh release create v$VERSION -F release_notes.txt --repo Teslemetry/hass-teslemetry -t "Beta v$VERSION"
-gh release upload v$VERSION teslemetry.zip --repo Teslemetry/hass-teslemetry
-rm teslemetry.zip
-git push --set-upstream origin release-$VERSION
-```
+Two independent gates guard the real release: the interactive `publish` confirmation **and** the `--publish` flag. Without `--publish`, even an approved run stops at a dry run that prints what it would do - so validating the pipeline never risks a real tag or GitHub release. With both, the script tags `v$VERSION`, zips the integration, runs `gh release create ... --prerelease` + upload, then **guarantees** the prerelease flag with a typed API PATCH (`gh api --method PATCH .../releases/$id -F prerelease=true`; never `gh release edit`, which resets it), and pushes `release-$VERSION`.
 
 ## Conflict resolution guidelines
 
@@ -194,14 +70,14 @@ These live only in this HACS tree, never upstream. They are re-applied on top of
 
 `.github/workflows/teslemetry-test.yml` is the only PR/push CI gate this repo keeps: a fork-owned file that runs `pytest tests/components/teslemetry`, ruff, and hassfest scoped to just the integration, on every PR/push to `main` and push to `release-*`. Treat this job as the pass/fail gate for whether the integration itself is healthy.
 
-Core `dev` carries a much larger `.github/workflows/` set that would otherwise run whole-repo and fail here as fork-irrelevant noise (whole-repo hassfest, prek, workflow/copilot-instructions checks, requirements-lock bots, CodeQL, the HAOS/supervisor `builder`/`wheels` pipelines, translation sync, manual e2e-tests). These are deleted, and step 2's sync-dev strip (see above) re-deletes them every release so the merge from core `dev` can't bring them back: `ci.yaml`, `validate.yml`, `check-requirements-deterministic.yml`, `check-requirements.lock.yml`, `check-requirements.md`, `codeql.yml`, `translations.yml`, `builder.yml`, `wheels.yml`, `e2e-tests.yml`, `matchers/`. A red check from any of these reappearing means the step 2 strip didn't run or missed a path - not a signal about the integration.
+Core `dev` carries a much larger `.github/workflows/` set that would otherwise run whole-repo and fail here as fork-irrelevant noise (whole-repo hassfest, prek, workflow/copilot-instructions checks, requirements-lock bots, CodeQL, the HAOS/supervisor `builder`/`wheels` pipelines, translation sync, manual e2e-tests). These are deleted, and `release.sh`'s `sync_dev` strip (`strip_core_ci`, from the same `CORE_CI_PATHS` list) re-deletes them every release so the merge from core `dev` can't bring them back: `ci.yaml`, `validate.yml`, `check-requirements-deterministic.yml`, `check-requirements.lock.yml`, `check-requirements.md`, `codeql.yml`, `translations.yml`, `builder.yml`, `wheels.yml`, `e2e-tests.yml`, `matchers/`. A red check from any of these reappearing means the strip didn't run or missed a path - not a signal about the integration.
 
 Kept alongside `teslemetry-test.yml` because they aren't PR/push CI noise: `release.yml` (HACS-specific - posts the GitHub release to Discord) and the issue-automation bots `detect-duplicate-issues.yml`, `detect-non-english-issues.yml`, `stale.yml`, `lock.yml`, `restrict-task-creation.yml` (manage this fork's own Issues, unrelated to the PR/push gate).
 
 - `manifest.json`'s `issue_tracker` key (pointing at this fork's own issue tracker) is deliberate, but hassfest's `manifest` plugin only permits that key on integrations it treats as "custom" - and it classifies anything under `homeassistant/components/` as core regardless of `--integration-path` scoping, so real hassfest always rejects it here. This is structural, not a bug: the workflow runs hassfest with `--skip-plugins manifest` to avoid a permanent false-positive; everything else hassfest checks still runs.
-- Test dependencies: install `requirements_all.txt` + `requirements_test.txt` (+ `requirements_test_pre_commit.txt` for ruff), same as `script/bootstrap`/`ci.yaml` and step 6 above. There is no `requirements_test_all.txt` in this checkout - don't chase it if you see it referenced.
+- Test dependencies: install `requirements_all.txt` + `requirements_test.txt` (+ `requirements_test_pre_commit.txt` for ruff), same as `script/bootstrap`/`ci.yaml` and `release.sh`'s `build_gate`. There is no `requirements_test_all.txt` in this checkout - don't chase it if you see it referenced.
 - Before `pytest`, translations must be compiled for **all** integrations (`python3 -m script.translations develop --all`, <1s, no network) or `check_translations` (`tests/components/conftest.py`) fails any test touching a platform teslemetry's entities inherit services from (e.g. `media_player`, `button`) - not just teslemetry itself. `homeassistant/components/*/translations` is gitignored except teslemetry's own, so this is never pre-populated on a fresh checkout; a local worktree with stale generated files from an earlier `--all` run will falsely pass with only `--integration teslemetry` compiled - verify translation-dependent changes against a clean checkout, not a dev worktree.
-- Publish gating: this workflow alone can't block `gh release create` (step 8) - it's a manual command outside any workflow, and this repo doesn't use branch-protection required-checks (captain gates at publish, not via a GitHub repo setting). The actual gate is build step 6, which runs this same suite locally and stops the release crew cold on any failure before step 7/8 are reached.
+- Publish gating: this workflow alone can't block `gh release create` - it's a manual command outside any workflow, and this repo doesn't use branch-protection required-checks (captain gates at publish, not via a GitHub repo setting). The actual gate is `release.sh`'s `build_gate`, which runs this same suite locally and stops the release cold on any failure before the approval pause and publish are ever reached.
 
 ## Maintaining this file
 

--- a/release.sh
+++ b/release.sh
@@ -1,56 +1,380 @@
-# Get everything up to date
-git checkout main
-git fetch upstream dev
-git rebase upstream/dev
-git push --force-with-lease
+#!/usr/bin/env bash
+#
+# Reproducible HACS beta release pipeline for hass-teslemetry.
+#
+# Usage:  ./release.sh <major|minor|patch> [--publish]
+#
+# This script IS the release process. AGENTS.md's "Task: build a release"
+# section documents WHY each step exists and the gotchas behind each gate;
+# this file owns HOW. Keep the two in sync when either changes.
+#
+# It runs the deterministic steps mechanically and hard-enforces the gates the
+# old prose runbook trusted an operator to remember (the device_tracker
+# ATTR_LATITUDE compat grep that v6.0.9 missed; the post-commit conflict-marker
+# grep; the full local build gate). It STOPS for a human at exactly two kinds
+# of checkpoint: an unresolved conflict, and the pre-publish approval pause.
+# It never auto-publishes: the real tag/release only runs with --publish AND an
+# explicit human "publish" at the approval pause.
+#
+# Safe to run from an isolated worktree: it never checks out main, never
+# rebases, and never force-pushes. Every update to main goes through the
+# temporary sync-dev branch delivered with a plain non-force push.
 
-# Ask for version
-echo "Last version:"
-gh release ls --repo teslemetry/hass-teslemetry --limit 1
-echo "New version:"
-read VERSION
+set -euo pipefail
 
-git branch -D release-$VERSION
-git checkout -b release-$VERSION
+# --- fork remotes / repo -----------------------------------------------------
+FORK_REPO="Teslemetry/hass-teslemetry"      # origin: the HACS fork we release
+CORE_REPO="home-assistant/core"             # upstream: core, source of PRs/dev
+INTEGRATION="homeassistant/components/teslemetry"
+DEVICE_TRACKER="$INTEGRATION/device_tracker.py"
 
-rm release_notes.txt
+# Core CI/CD workflows this fork deliberately excludes. The core-dev sync would
+# otherwise resurrect them; stripped every cut. Keep in sync with the identical
+# list in AGENTS.md ("CI: the clean per-integration gate").
+CORE_CI_PATHS=(
+  .github/workflows/ci.yaml
+  .github/workflows/validate.yml
+  .github/workflows/check-requirements-deterministic.yml
+  .github/workflows/check-requirements.lock.yml
+  .github/workflows/check-requirements.md
+  .github/workflows/codeql.yml
+  .github/workflows/translations.yml
+  .github/workflows/builder.yml
+  .github/workflows/wheels.yml
+  .github/workflows/e2e-tests.yml
+  .github/workflows/matchers
+)
 
-for PR_NUMBER in $(gh pr list --repo home-assistant/core --author Bre77 --state open --label "integration: teslemetry" --json number | jq -r '.[].number'); do
-    PR_TITLE=$(gh pr view $PR_NUMBER --repo home-assistant/core --json title | jq -r '.title')
-    echo "Applying patch from PR #$PR_NUMBER: $PR_TITLE"
-    gh pr diff $PR_NUMBER --patch --repo home-assistant/core | git apply -3
-    git mergetool
-    git commit -am "#$PR_NUMBER: $PR_TITLE" --no-verify
-    echo "[#$PR_NUMBER](https://github.com/home-assistant/core/pull/$PR_NUMBER): $PR_TITLE" >> release_notes.txt
-done
+# --- output helpers ----------------------------------------------------------
+log()  { printf '\n\033[1;36m==> %s\033[0m\n' "$*"; }
+info() { printf '    %s\n' "$*"; }
+die()  { printf '\n\033[1;31mFAIL: %s\033[0m\n' "$*" >&2; exit 1; }
 
-yq -i -o json ".version=\"$VERSION\"" "homeassistant/components/teslemetry/manifest.json"
-cp "homeassistant/components/teslemetry/manifest.json" "custom_components/teslemetry/manifest.json"
-echo "" >> release_notes.txt
-echo "**Full Changelog**: https://github.com/Teslemetry/hass-teslemetry/commits/v$VERSION" >> release_notes.txt
+# Human checkpoint. Blocks until the operator confirms they have handled what
+# the message describes. Reads from the terminal even inside a pipeline.
+pause() {
+  printf '\n\033[1;33m>>> %s\033[0m\n' "$*"
+  read -r -p "    Press Enter to continue, or Ctrl-C to abort: " _ < /dev/tty
+}
 
-git commit -am "v$VERSION" --no-verify
+# --- gate helpers ------------------------------------------------------------
 
-source .venv/bin/activate
-script/setup
-uv pip install -r requirements_test_all.txt
-pytest tests/components/teslemetry
-deactivate
+# Fail if any tracked file carries a leftover conflict marker. Optional
+# pathspecs narrow the search. Enforced after every commit that could have
+# merged or applied a patch. git grep searches tracked files only, which is
+# exactly what we want post-commit.
+assert_no_conflict_markers() {
+  if git grep -nE '^(<{7}|>{7})( |$)' -- "$@" 2>/dev/null; then
+    die "conflict markers found (above) - resolve before continuing"
+  fi
+  info "no conflict markers"
+}
 
-read -p "Press Enter to release..."
+# Complete an in-progress merge/apply only once the tree is fully resolved.
+assert_no_unmerged() {
+  if [ -n "$(git diff --name-only --diff-filter=U)" ]; then
+    git diff --name-only --diff-filter=U | sed 's/^/    unmerged: /'
+    die "unmerged paths remain - 'git add' every resolved file, then rerun this step"
+  fi
+}
 
-git tag -a v$VERSION -m "Release $VERSION"
-git push origin v$VERSION
-cd homeassistant/components/teslemetry
-rm -r __pycache__
-rm *.orig
-zip -r ../../../teslemetry.zip *
-cd ../../..
-gh release create v$VERSION -F release_notes.txt --repo Teslemetry/hass-teslemetry -t "Beta v$VERSION"
-gh release upload v$VERSION teslemetry.zip --repo Teslemetry/hass-teslemetry
-rm teslemetry.zip
-git push --set-upstream origin release-$VERSION
+# --- steps -------------------------------------------------------------------
 
+parse_args() {
+  BUMP=""
+  PUBLISH=0
+  for arg in "$@"; do
+    case "$arg" in
+      major|minor|patch) BUMP="$arg" ;;
+      --publish)         PUBLISH=1 ;;
+      *) die "unknown argument: $arg (usage: ./release.sh <major|minor|patch> [--publish])" ;;
+    esac
+  done
+  [ -n "$BUMP" ] || die "specify one of: major | minor | patch"
+}
 
-git checkout main
-git restore .
+preflight() {
+  log "Preflight"
+  # Never operate from a main checkout: checking out / committing on main in a
+  # shared clone dirties it. This pipeline only ever touches temp branches.
+  local branch
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  [ "$branch" = "main" ] && die "on 'main' - run this from an isolated worktree/branch, never a main checkout"
+
+  [ -z "$(git status --porcelain)" ] || die "working tree is dirty - start from a clean checkout"
+
+  git remote get-url origin   >/dev/null 2>&1 || die "no 'origin' remote (expected $FORK_REPO)"
+  git remote get-url upstream >/dev/null 2>&1 || die "no 'upstream' remote (expected $CORE_REPO)"
+
+  for tool in gh yq jq git; do
+    command -v "$tool" >/dev/null 2>&1 || die "required tool not found: $tool"
+  done
+  if [ "$PUBLISH" = 1 ]; then
+    command -v zip >/dev/null 2>&1 || die "'zip' required for --publish"
+  fi
+  info "branch=$branch publish=$PUBLISH"
+}
+
+# Step 1: determine and bump the version off the latest published release.
+determine_version() {
+  log "Step 1: determine version"
+  local last major minor patch
+  last=$(gh release list --repo "$FORK_REPO" --limit 1 --json tagName --jq '.[0].tagName')
+  [ -n "$last" ] || die "could not read latest release tag from $FORK_REPO"
+  info "latest release: $last"
+
+  IFS='.' read -r major minor patch <<<"${last#v}"
+  [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ && "$patch" =~ ^[0-9]+$ ]] \
+    || die "cannot parse semver from '$last'"
+
+  case "$BUMP" in
+    major) major=$((major + 1)); minor=0; patch=0 ;;
+    minor) minor=$((minor + 1)); patch=0 ;;
+    patch) patch=$((patch + 1)) ;;
+  esac
+  VERSION="$major.$minor.$patch"
+  info "new version: $VERSION ($BUMP bump)"
+}
+
+# Re-delete the core CI/CD workflows and commit if anything was staged.
+# --ignore-unmatch makes it a no-op when upstream didn't touch these paths.
+strip_core_ci() {
+  git rm -rf --ignore-unmatch "${CORE_CI_PATHS[@]}" >/dev/null 2>&1 || true
+  if ! git diff --cached --quiet; then
+    git commit -m "Strip core CI/CD workflow noise" --no-verify >/dev/null
+    info "stripped core CI/CD workflows"
+  fi
+}
+
+# Step 2: sync main with upstream dev via a temp branch and a non-force push.
+sync_dev() {
+  log "Step 2: sync main with upstream dev"
+  git fetch origin main
+  git fetch upstream dev
+
+  git branch -D sync-dev >/dev/null 2>&1 || true
+  git checkout -b sync-dev origin/main
+
+  if ! git merge --no-edit upstream/dev; then
+    pause "Merge conflicts from upstream/dev. Edit files to resolve (no mergetool), 'git add' each resolved file. Do NOT commit - this script finishes the merge."
+    assert_no_unmerged
+    git commit --no-edit --no-verify
+  fi
+  strip_core_ci
+  assert_no_conflict_markers
+
+  # Non-force push with concurrent-push retry: if main moved under us, fold in
+  # the new origin/main and retry. Never --force / --force-with-lease.
+  local tries=0
+  until git push origin sync-dev:main; do
+    tries=$((tries + 1))
+    [ "$tries" -ge 3 ] && die "push to main rejected $tries times - resolve manually and rerun"
+    log "push rejected (main moved) - re-merging origin/main (attempt $tries)"
+    git fetch origin main
+    if ! git merge --no-edit origin/main; then
+      pause "Conflicts merging the newer origin/main. Resolve and 'git add'; do NOT commit."
+      assert_no_unmerged
+      git commit --no-edit --no-verify
+    fi
+    strip_core_ci
+  done
+  info "main synced (non-force push)"
+}
+
+# Step 3: cut the release branch off the just-synced state.
+create_release_branch() {
+  log "Step 3: create release branch"
+  git branch -D "release-$VERSION" >/dev/null 2>&1 || true
+  git checkout -b "release-$VERSION"
+  info "on release-$VERSION"
+}
+
+# Remove one file's section from a unified diff read on stdin. Used to hold
+# quality_scale.yaml out of per-PR patches (TEMPORARY, see apply_prs).
+strip_file_from_diff() {
+  local drop="$1"
+  awk -v drop="$drop" '
+    /^diff --git / { keep = ($0 !~ drop) }
+    keep { print }
+  '
+}
+
+# Step 4: apply Bre77 open core PRs oldest-to-newest. JUDGMENT checkpoint:
+# clean applies auto-commit; any conflict STOPS for manual resolution. Per-PR
+# note lines are collected here and written to release_notes.txt in
+# update_version - never a tracked file, so `git add -A` can't stage it.
+apply_prs() {
+  log "Step 4: apply core PR patches"
+
+  APPLIED_PRS=()
+  CONFLICTED_PRS=()
+  NOTE_LINES=()
+
+  # Oldest-to-newest == ascending PR number (proxy the runbook already uses).
+  local prs
+  prs=$(gh pr list --repo "$CORE_REPO" --author Bre77 --state open \
+        --label "integration: teslemetry" --json number,title \
+        --jq 'sort_by(.number)[] | "\(.number)\t\(.title)"')
+
+  if [ -z "$prs" ]; then
+    info "no open Bre77 teslemetry PRs to apply"
+  else
+    local num title
+    while IFS=$'\t' read -r num title; do
+      [ -n "$num" ] || continue
+      log "  PR #$num: $title"
+      # TEMPORARY (quality-scale work in progress): keep quality_scale.yaml out
+      # of every per-PR patch to avoid repeated conflicts; the combined final
+      # state is applied once at the end below. Remove this filter and the
+      # end-of-loop checkpoint once the quality scale PRs have all merged.
+      if gh pr diff "$num" --patch --repo "$CORE_REPO" \
+           | strip_file_from_diff "quality_scale.yaml" \
+           | git apply -3; then
+        info "applied cleanly"
+      else
+        CONFLICTED_PRS+=("#$num")
+        pause "PR #$num did not apply cleanly. Read its intent (gh pr diff $num --repo $CORE_REPO), edit files to resolve, 'git add' each. Do NOT commit - this script commits."
+        assert_no_unmerged
+      fi
+      # -A (not -am): capture any new files the patch adds (e.g. a new calendar.py).
+      git add -A
+      git commit -m "#$num: $title" --no-verify >/dev/null
+      # Enforce the post-commit marker grep the runbook left to memory.
+      assert_no_conflict_markers "$INTEGRATION" tests/components/teslemetry
+      NOTE_LINES+=("[#$num](https://github.com/$CORE_REPO/pull/$num): $title")
+      APPLIED_PRS+=("#$num $title")
+    done <<<"$prs"
+  fi
+
+  # TEMPORARY: apply the combined final quality_scale.yaml once (judgment step).
+  pause "quality_scale.yaml was excluded from every patch above. If it changed in any PR, apply the correct combined final state now (read the PRs' final quality_scale.yaml and write it), 'git add' it. Leave it untouched if no PR changed it."
+  if ! git diff --cached --quiet; then
+    git commit -m "Apply combined quality_scale.yaml" --no-verify >/dev/null
+    info "committed combined quality_scale.yaml"
+  fi
+  assert_no_conflict_markers "$INTEGRATION" tests/components/teslemetry
+}
+
+# Step 5: stamp version into both manifests and write release_notes.txt.
+# release_notes.txt stays untracked: it feeds `gh release create -F`, not a commit.
+update_version() {
+  log "Step 5: update version and manifests"
+
+  # Standing compatibility note, verbatim, before any per-PR lines.
+  cat > release_notes.txt <<'NOTE'
+> ⚠️ **Compatibility with the built-in Tessie and Tesla Fleet integrations**
+>
+> This beta pins a newer `tesla-fleet-api` than the latest released Home Assistant Core version ships. The built-in **Tessie** and **Tesla Fleet** integrations share that library, so this beta is incompatible with them whenever its pinned `tesla-fleet-api` is ahead of the version in the latest core release — which is almost always. Do not run this beta alongside the built-in Tessie or Tesla Fleet integrations.
+NOTE
+  local line
+  for line in ${NOTE_LINES[@]+"${NOTE_LINES[@]}"}; do printf '%s\n' "$line" >> release_notes.txt; done
+  printf '\n**Full Changelog**: https://github.com/%s/commits/v%s\n' "$FORK_REPO" "$VERSION" >> release_notes.txt
+
+  yq -i -o json ".version=\"$VERSION\"" "$INTEGRATION/manifest.json"
+  cp "$INTEGRATION/manifest.json" "custom_components/teslemetry/manifest.json"
+  git commit -am "v$VERSION" --no-verify >/dev/null
+  info "manifests at $VERSION, release_notes.txt written"
+}
+
+# Hard gate: the stable-core device_tracker compat shim v6.0.9 shipped broken.
+# The break is stable-core-only, so the dev-form build gate passes green - this
+# grep is the only thing that catches it. See AGENTS.md for the full why.
+device_tracker_gate() {
+  log "Gate: device_tracker stable-core ATTR_LATITUDE compat"
+  [ -f "$DEVICE_TRACKER" ] || die "$DEVICE_TRACKER missing"
+  grep -q 'ATTR_LATITUDE'  "$DEVICE_TRACKER" || die "device_tracker.py must import/use ATTR_LATITUDE (not the dev-only enum member)"
+  grep -q 'ATTR_LONGITUDE' "$DEVICE_TRACKER" || die "device_tracker.py must import/use ATTR_LONGITUDE (not the dev-only enum member)"
+  # Forbidden only in code: the enum members are 2026.8-dev-only and raise
+  # AttributeError on the stable cores HACS users run. Allowed inside comments.
+  local hits
+  hits=$(awk '{ code=$0; sub(/#.*/,"",code);
+               if (code ~ /EntityStateAttribute\.(LATITUDE|LONGITUDE)/) print NR": "$0 }' \
+             "$DEVICE_TRACKER" || true)
+  [ -z "$hits" ] || die "device_tracker.py uses dev-only EntityStateAttribute.LATITUDE/.LONGITUDE in code:
+$hits"
+  info "ATTR_LATITUDE/ATTR_LONGITUDE present, dev-only enum absent from code"
+}
+
+# Step 6: full local build gate - the actual publish gate for this repo.
+# Mirrors .github/workflows/teslemetry-test.yml command-for-command. Blocks the
+# release on any failure before the approval pause is ever reached.
+build_gate() {
+  log "Step 6: build gate (blocking)"
+  [ -d .venv ] || script/setup
+  # shellcheck disable=SC1091
+  source .venv/bin/activate
+  script/setup
+  uv pip install -r requirements_all.txt -r requirements_test.txt -r requirements_test_pre_commit.txt
+  # --all (not --integration teslemetry): entities inherit services from other
+  # platforms whose translations check_translations needs compiled. See AGENTS.md.
+  python3 -m script.translations develop --all
+  # --skip-plugins manifest: the manifest plugin rejects this fork's HACS-only
+  # issue_tracker key as a structural false positive. See AGENTS.md.
+  python3 -m script.hassfest --integration-path "$INTEGRATION" --skip-plugins manifest
+  ruff check "$INTEGRATION" tests/components/teslemetry
+  ruff format --check "$INTEGRATION" tests/components/teslemetry
+  pytest tests/components/teslemetry
+  deactivate
+  info "build gate green"
+}
+
+# Steps 7 & 8: approval pause, then publish. Never auto-publishes.
+approve_and_publish() {
+  log "Step 7: approval"
+  echo
+  info "Version:  v$VERSION"
+  info "Applied PRs:"
+  if [ "${#APPLIED_PRS[@]}" -eq 0 ]; then info "  (none)"; else printf '      - %s\n' "${APPLIED_PRS[@]}"; fi
+  if [ "${#CONFLICTED_PRS[@]}" -gt 0 ]; then
+    info "Conflicts resolved during apply: ${CONFLICTED_PRS[*]}"
+  fi
+  info "Build gate: green (step 6 passed in full)"
+  echo
+
+  local ans
+  read -r -p "    Type 'publish' to tag & release v$VERSION, anything else aborts: " ans < /dev/tty
+  [ "$ans" = "publish" ] || { info "aborted at approval - nothing published"; exit 0; }
+
+  if [ "$PUBLISH" != 1 ]; then
+    log "DRY RUN (no --publish flag)"
+    info "Approved, but --publish was not passed. Would now:"
+    info "  git tag -a v$VERSION && git push origin v$VERSION"
+    info "  zip the integration and gh release create/upload v$VERSION on $FORK_REPO (prerelease)"
+    info "  git push --set-upstream origin release-$VERSION"
+    info "Rerun with --publish to perform the real release."
+    exit 0
+  fi
+
+  log "Step 8: publish"
+  git tag -a "v$VERSION" -m "Release $VERSION"
+  git push origin "v$VERSION"
+
+  ( cd "$INTEGRATION" && rm -rf __pycache__ && rm -f ./*.orig && zip -r ../../../teslemetry.zip ./* >/dev/null )
+  gh release create "v$VERSION" -F release_notes.txt --repo "$FORK_REPO" -t "Beta v$VERSION" --prerelease
+  gh release upload "v$VERSION" teslemetry.zip --repo "$FORK_REPO"
+  rm -f teslemetry.zip
+
+  # Guarantee the prerelease flag with a TYPED API PATCH (-F sends a real
+  # boolean). Never `gh release edit`, which resets prerelease to false.
+  local rel_id
+  rel_id=$(gh release view "v$VERSION" --repo "$FORK_REPO" --json databaseId --jq '.databaseId')
+  gh api --method PATCH "repos/$FORK_REPO/releases/$rel_id" -F prerelease=true >/dev/null
+
+  git push --set-upstream origin "release-$VERSION"
+  log "Published v$VERSION (prerelease) on $FORK_REPO"
+}
+
+main() {
+  parse_args "$@"
+  preflight
+  determine_version
+  sync_dev
+  create_release_branch
+  apply_prs
+  update_version
+  device_tracker_gate
+  build_gate
+  approve_and_publish
+}
+
+main "$@"


### PR DESCRIPTION
## Intent

- **Problem**: the release process was a long prose runbook (`AGENTS.md` steps 1-8) an operator followed by hand each cut, relying on memory for MUST-DO gates. v6.0.9 shipped broken `location`/`route` device_trackers to every stable-core user because the operator skipped the `device_tracker.py` `ATTR_LATITUDE` compat grep - a gate green CI cannot catch (the break is stable-core-only; the build gate runs against dev-form core). Any hand-run step can drift or be forgotten.
- **Fix**: move the deterministic HOW into a committed helper, `release.sh` (repo root, invoked `./release.sh <major|minor|patch> [--publish]`), and rewrite the `AGENTS.md` build-a-release section to point at it instead of duplicating steps that can drift.
  - **Mechanized + fail-stop**: version bump; the `sync-dev` merge + CI-strip + non-force `git push origin sync-dev:main` (with concurrent-push re-merge/retry, never force); the post-commit conflict-marker grep; the `device_tracker.py` `ATTR_LATITUDE`-present / dev-only-`EntityStateAttribute.LATITUDE`-absent grep; both manifests; the full local build gate; the compat note prepended verbatim; and `--prerelease` guaranteed via a typed API PATCH (never `gh release edit`).
  - **Human checkpoints preserved**: the pipeline pauses for manual resolution on any conflict, once for the TEMPORARY combined `quality_scale.yaml`, and for explicit `publish` approval before tagging. It never auto-publishes - the real release needs both the approval and the `--publish` flag.
  - **Placement**: fork-only tracked file at the root, like `.github/workflows/teslemetry-test.yml`; core `dev` has no `release.sh`, so the dev-sync merge and the `.github/workflows/` CI-strip both leave it untouched. Documented in `AGENTS.md`.
- **Safe from an isolated worktree**: no `git checkout main`, no rebase, no force-push - every `main` update goes through a temp branch.

Validated without cutting a real release: script syntax, the version-bump/arg-parsing logic, the `device_tracker` and conflict-marker gates (including inline-comment edge cases), the `quality_scale.yaml` diff filter, and the apply→`git add -A`→commit→grep flow (incl. a new-file-adding patch) were exercised in a sandbox; the compat note is byte-identical to the prior runbook's. The publish path is gated behind `--publish`, left off throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
