### PR TITLE
Derive next release version from git tags, not the release list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ The whole release runs through one committed helper, **`release.sh`** (repo root
 
 ### What the pipeline does, and where it stops for you
 
-It runs every release phase automatically: version bump off the latest release; the `sync-dev` merge of `upstream/dev` + CI-strip + **non-force** `git push origin sync-dev:main` (with concurrent-push re-merge/retry); cutting `release-$VERSION`; applying Bre77's open core PRs oldest-to-newest; stamping both manifests; writing `release_notes.txt` (standing compat note prepended verbatim); the full local build gate; then the approval pause and publish. It **never** runs `git checkout main`, rebases, or force-pushes, so it is safe from an isolated worktree.
+It runs every release phase automatically: version bump off the latest release **tag** (`git tag -l 'v*'`, version-sorted - tags are the durable record even when a release object is deleted, e.g. a yanked build whose tag is kept, and this matches the source `aiopowerwall_pin_gate` reads); the `sync-dev` merge of `upstream/dev` + CI-strip + **non-force** `git push origin sync-dev:main` (with concurrent-push re-merge/retry); cutting `release-$VERSION`; applying Bre77's open core PRs oldest-to-newest; stamping both manifests; writing `release_notes.txt` (standing compat note prepended verbatim); the full local build gate; then the approval pause and publish. It **never** runs `git checkout main`, rebases, or force-pushes, so it is safe from an isolated worktree.
 
 It pauses and hands control to you at exactly these points; everything else is automatic and fail-stop:
 

--- a/release.sh
+++ b/release.sh
@@ -117,13 +117,18 @@ preflight() {
   info "branch=$branch publish=$PUBLISH"
 }
 
-# Step 1: determine and bump the version off the latest published release.
+# Step 1: determine and bump the version off the latest release tag.
+# Tags, not the GitHub release list, are the durable record of which version
+# numbers have been used: a release object can be deleted while its tag is kept,
+# as when a bad build is yanked. Keying off releases would then recompute the
+# yanked number and collide with the retained tag at publish. Reading tags also
+# matches aiopowerwall_pin_gate, so the version driver and pin floor agree.
 determine_version() {
   log "Step 1: determine version"
   local last major minor patch
-  last=$(gh release list --repo "$FORK_REPO" --limit 1 --json tagName --jq '.[0].tagName')
-  [ -n "$last" ] || die "could not read latest release tag from $FORK_REPO"
-  info "latest release: $last"
+  last=$(git tag -l 'v*' | sort -V | tail -1)
+  [ -n "$last" ] || die "could not read latest release tag from git (no 'v*' tags found)"
+  info "latest release tag: $last"
 
   IFS='.' read -r major minor patch <<<"${last#v}"
   [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ && "$patch" =~ ^[0-9]+$ ]] \

--- a/release.sh
+++ b/release.sh
@@ -123,9 +123,13 @@ preflight() {
 # as when a bad build is yanked. Keying off releases would then recompute the
 # yanked number and collide with the retained tag at publish. Reading tags also
 # matches aiopowerwall_pin_gate, so the version driver and pin floor agree.
+# Release tags point at release branches, not main, so main's fetches never
+# bring them down - fetch tags first, or a stale local list recomputes a taken
+# version and reopens this very bug. Fail loud rather than read a stale list.
 determine_version() {
   log "Step 1: determine version"
   local last major minor patch
+  git fetch --tags origin || die "could not fetch tags from origin - refusing to compute a version off a stale local tag list"
   last=$(git tag -l 'v*' | sort -V | tail -1)
   [ -n "$last" ] || die "could not read latest release tag from git (no 'v*' tags found)"
   info "latest release tag: $last"


### PR DESCRIPTION
`release.sh`'s `determine_version()` bumped off `gh release list`, which reports release *objects*. Releases can be deleted while their tag is kept — as when a bad build is yanked. v6.0.12 was published, then yanked (release deleted, tag retained), so `gh release list` now reports v6.0.11 and a `patch` bump recomputes **6.0.12**, colliding with the retained tag at publish and re-offering the withdrawn version to anyone already on it.

Derive `last` from the latest `v*` tag (version-sorted), the same source `aiopowerwall_pin_gate` already reads, so the version driver and pin floor agree. Semver parse, bump arithmetic, and fail-closed behaviour on no tag are unchanged.

Because release tags point at `release-*` branches (not `main`) and the pipeline only fetches `origin/main` and `upstream/dev`, the tag read is done against remote state explicitly: `determine_version` now runs `git fetch --tags origin` first and `die`s if it fails — otherwise a fresh clone or a pooled worktree that never ran the latest cut would read a stale local list and recompute an already-taken version, reopening this same bug. Plain `--tags` (not `--prune-tags`): the yanked tag is deliberately kept, so there is nothing to prune, and pruning would needlessly risk a tag `aiopowerwall_pin_gate` reads mid-run.

Against the live tag list this yields `v6.0.12`, so a `patch` bump gives `6.0.13`.
