### PR TITLE
Fix Teslemetry calendar crash on end-of-day tariff hour 24

### DIFF
--- a/homeassistant/components/teslemetry/calendar.py
+++ b/homeassistant/components/teslemetry/calendar.py
@@ -46,6 +46,16 @@ def _is_day_in_range(day_of_week: int, from_day: int, to_day: int) -> bool:
     return day_of_week >= from_day or day_of_week <= to_day
 
 
+def _period_datetime(base_day: datetime, hour: int, minute: int) -> datetime:
+    """Resolve a tariff hour/minute, normalising the hour-24 and minute-60 end-of-boundary encodings."""
+    # Tesla marks an end of day as hour 24 and an end of hour as minute 60, both of
+    # which datetime.replace rejects, so roll the overflow into the hour and day.
+    day_offset, hour = divmod(hour + minute // 60, 24)
+    return base_day.replace(
+        hour=hour, minute=minute % 60, second=0, microsecond=0
+    ) + timedelta(days=day_offset)
+
+
 def _parse_period_times(
     period_def: dict[str, Any],
     base_day: datetime,
@@ -62,18 +72,12 @@ def _parse_period_times(
     if not _is_day_in_range(base_day.weekday(), from_day, to_day):
         return None
 
-    # Hours are from 0-23, so 24 hours is 0-0
-    from_hour = period_def.get("fromHour", 0)
-    to_hour = period_def.get("toHour", 0)
-
-    # Minutes are from 0-59, so 60 minutes is 0-0
-    from_minute = period_def.get("fromMinute", 0)
-    to_minute = period_def.get("toMinute", 0)
-
-    start_time = base_day.replace(
-        hour=from_hour, minute=from_minute, second=0, microsecond=0
+    start_time = _period_datetime(
+        base_day, period_def.get("fromHour", 0), period_def.get("fromMinute", 0)
     )
-    end_time = base_day.replace(hour=to_hour, minute=to_minute, second=0, microsecond=0)
+    end_time = _period_datetime(
+        base_day, period_def.get("toHour", 0), period_def.get("toMinute", 0)
+    )
 
     if end_time <= start_time:
         end_time += timedelta(days=1)

--- a/tests/components/teslemetry/test_calendar.py
+++ b/tests/components/teslemetry/test_calendar.py
@@ -79,6 +79,29 @@ def mock_site_info_invalid_season(mock_site_info) -> Generator[AsyncMock]:
 
 
 @pytest.fixture
+def mock_site_info_end_of_day(mock_site_info) -> Generator[AsyncMock]:
+    """Mock site_info with a real end-of-day tariff period ending at hour 24."""
+    site_info = deepcopy(SITE_INFO)
+    tariff = site_info["response"]["tariff_content_v2"]
+    # 23:30->24:00 period taken verbatim from a PowerSync Flow Power tariff,
+    # where Tesla encodes the end of the day as hour 24.
+    tariff["energy_charges"]["Summer"]["rates"] = {"PERIOD_23_30": 0.3561}
+    tariff["seasons"]["Summer"]["tou_periods"] = {
+        "PERIOD_23_30": {
+            "periods": [
+                {"toDayOfWeek": 6, "fromHour": 23, "fromMinute": 30, "toHour": 24}
+            ]
+        }
+    }
+    tariff["sell_tariff"]["seasons"] = {}
+    with patch(
+        "tesla_fleet_api.tesla.energysite.EnergySite.site_info",
+        side_effect=lambda: deepcopy(site_info),
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
 def mock_site_info_invalid_price(mock_site_info) -> Generator[AsyncMock]:
     """Mock site_info with non-numeric price data."""
     site_info = deepcopy(SITE_INFO)
@@ -379,6 +402,44 @@ async def test_calendar_midnight_crossing_local_start(
     assert starts[0].day == 31  # Dec 31 21:00 (previous evening)
     assert starts[1].day == 1  # Jan 1 16:00
     assert starts[2].day == 1  # Jan 1 21:00
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_calendar_end_of_day_period(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_legacy: AsyncMock,
+    mock_site_info_end_of_day: AsyncMock,
+) -> None:
+    """Test a tariff period ending at hour 24 parses instead of crashing."""
+    tz = dt_util.get_default_time_zone()
+    # Sunday 23:45, inside the 23:30->24:00 end-of-day period
+    freezer.move_to(datetime(2024, 1, 7, 23, 45, 0, tzinfo=tz))
+
+    await setup_platform(hass, [Platform.CALENDAR])
+
+    # Before the fix, hour 24 raised ValueError while the state was written
+    state = hass.states.get(ENTITY_BUY)
+    assert state
+    assert state.state == "on"
+
+    result = await hass.services.async_call(
+        CALENDAR_DOMAIN,
+        SERVICE_GET_EVENTS,
+        {
+            ATTR_ENTITY_ID: [ENTITY_BUY],
+            EVENT_START_DATETIME: datetime(2024, 1, 7, 0, 0, 0, tzinfo=tz),
+            EVENT_END_DATETIME: datetime(2024, 1, 8, 0, 0, 0, tzinfo=tz),
+        },
+        blocking=True,
+        return_response=True,
+    )
+    events = result[ENTITY_BUY]["events"]
+    assert len(events) == 1
+    # Hour 24 normalises to the following midnight
+    assert dt_util.parse_datetime(events[0]["end"]) == datetime(
+        2024, 1, 8, 0, 0, 0, tzinfo=tz
+    )
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Energy Site tariff schedule calendar fails to write its state on every coordinator update when a time-of-use period ends at hour 24. Tesla encodes the end of the day as `"toHour": 24` (and, per the payload, the end of an hour as minute 60) — for example a real PowerSync Flow Power tariff carries a `23:30 → 24:00` period. `_parse_period_times` passed those values straight into `datetime.replace(hour=...)`, which raises `ValueError: hour must be in 0..23`. The exception propagates out of `_handle_coordinator_update`, so the calendar entity never updates.

The code's own comments ("24 hours is 0-0", "60 minutes is 0-0") describe this boundary encoding, but the normalisation was never implemented. The values are drawn from the same four fields feeding both the start and end `replace()` calls, so the fix normalises all of them in one helper: hour 24 rolls to the following midnight and minute 60 rolls into the next hour, while every in-range value keeps the existing behaviour exactly. This is a targeted normalisation rather than broad tolerance because the payload's encoding is documented and known, not open-ended.

The regression test drives the exact end-of-day period taken from a real tariff payload and asserts the period resolves to the following midnight.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
