### PR TITLE
Document release.sh staleness for tag-based cuts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@ It pauses and hands control to you at exactly these points; everything else is a
 
 This guard is **not** a full inference of the line - a *cross-major* stable transition (a stable `v7.0.0` while `6.x` is still maintained) is undecidable from tags alone (the dead-vs-live lower-major problem above), so it is not covered; condition (a) catches that line while it is still in preview, which is when it is cut. Do not "simplify" the guard back to a bare `sort -V | tail -1`, and do not weaken the parse/bump arithmetic it feeds - the whole point is that a forgotten flag stops the release loudly instead of shipping the wrong series.
 
+An incremental cut based on a release TAG inherits that tag's frozen copy of `release.sh`, which may predate current gates and flags - the `v6.0.18` tree's copy had neither `--line` nor `services_child_devices_gate`. Any cut based on a tag must adopt `main`'s current `release.sh` before resolving the version or running gates, exactly as `RELEASE-6.1.md` already requires for the 6.1 line.
+
 ### What the gates guarantee (all fail-stop, enforced by the script)
 
 - **Conflict-marker grep after every commit** over the integration + tests - a leaked `<<<<<<<`/`>>>>>>>` stops the release.


### PR DESCRIPTION
Release branches freeze a copy of `release.sh` at cut time. The 6.0 line's frozen copy (497 lines, from `release-6.0.18`) predates `--line`/`require_unambiguous_line` and `services_child_devices_gate` (575 lines on `main`, 12 combined matches) — so a future 6.0 maintenance cut driven by that tree's own script would silently lose the line guard that stops a 6.1 tag hijacking a 6.0 version number, and the gate that keeps `include_child_devices` regressions out.

`RELEASE-6.1.md` already documents adopting `main`'s current `release.sh` for the 6.1 line. `AGENTS.md` had no equivalent instruction for tag-based cuts on any line, so this codifies the same requirement there, next to where `--line` and the no-line guard are already documented.

A companion branch, `fm/release-sh-6.0-forward` (off `release-6.0.18` with `release.sh` replaced verbatim from `main`), is pushed as a ready base for the next 6.0 cut — not part of this PR.
